### PR TITLE
Python requirements file detection improvements

### DIFF
--- a/lib/bibliothecary/parsers/pypi.rb
+++ b/lib/bibliothecary/parsers/pypi.rb
@@ -7,8 +7,8 @@ module Bibliothecary
       REQUIREMENTS_REGEXP = /^#{REQUIRE_REGEXP}/
 
       def self.parse(filename, file_contents)
-        is_requirements_file = filename.match(/require.*\.(txt|pip)$/) or filename.match(/.*-requirements\.(txt|pip)$/)
-        if is_requirements_file && !filename.match(/^node_modules/)
+        is_valid_requirements_file = is_requirements_file(filename)
+        if is_valid_requirements_file
           parse_requirements_txt(file_contents)
         elsif filename.match(/^setup\.py$/)
           parse_setup_py(file_contents)
@@ -80,6 +80,15 @@ module Bibliothecary
           }
         end
         deps
+      end
+
+      def self.is_requirements_file(filename)
+        is_requirements_file = filename.match(/require.*\.(txt|pip)$/) or filename.match(/.*-requirements\.(txt|pip)$/)
+        if is_requirements_file and !filename.match(/^node_modules/)
+            return true
+        else
+            return false
+        end
       end
     end
   end

--- a/lib/bibliothecary/parsers/pypi.rb
+++ b/lib/bibliothecary/parsers/pypi.rb
@@ -83,11 +83,11 @@ module Bibliothecary
       end
 
       def self.is_requirements_file(filename)
-        is_requirements_file = filename.match(/require.*\.(txt|pip)$/) or filename.match(/.*-requirements\.(txt|pip)$/)
-        if is_requirements_file and !filename.match(/^node_modules/)
-            return true
+        is_requirements_file = filename.match(/require.*\.(txt|pip)$/)
+        if filename.match(/require.*\.(txt|pip)$/) and !filename.match(/^node_modules/)
+          return true
         else
-            return false
+          return false
         end
       end
     end

--- a/lib/bibliothecary/parsers/pypi.rb
+++ b/lib/bibliothecary/parsers/pypi.rb
@@ -7,7 +7,8 @@ module Bibliothecary
       REQUIREMENTS_REGEXP = /^#{REQUIRE_REGEXP}/
 
       def self.parse(filename, file_contents)
-        if filename.match(/require.*\.(txt|pip)$/) && !filename.match(/^node_modules/)
+        is_requirements_file = filename.match(/require.*\.(txt|pip)$/) or filename.match(/.*-requirements\.(txt|pip)$/)
+        if is_requirements_file && !filename.match(/^node_modules/)
           parse_requirements_txt(file_contents)
         elsif filename.match(/^setup\.py$/)
           parse_setup_py(file_contents)

--- a/spec/parsers/pypi_spec.rb
+++ b/spec/parsers/pypi_spec.rb
@@ -50,4 +50,13 @@ describe Bibliothecary::Parsers::Pypi do
       {:name=>"requests", :requirement=>"==0.11.1", :type=>"runtime"}
     ])
   end
+
+  it 'correctly detected different requirements.txt file names' do
+      expect(Bibliothecary::Parsers::Pypi.is_requirements_file('requirements.txt')).to be true
+      expect(Bibliothecary::Parsers::Pypi.is_requirements_file('requirements.pip')).to be true
+      expect(Bibliothecary::Parsers::Pypi.is_requirements_file('requirements-test.txt')).to be true
+      expect(Bibliothecary::Parsers::Pypi.is_requirements_file('requirements-test.pip')).to be true
+      expect(Bibliothecary::Parsers::Pypi.is_requirements_file('test-requirements.txt')).to be true
+      expect(Bibliothecary::Parsers::Pypi.is_requirements_file('test-requirements.pip')).to be true
+  end
 end

--- a/spec/parsers/pypi_spec.rb
+++ b/spec/parsers/pypi_spec.rb
@@ -58,5 +58,7 @@ describe Bibliothecary::Parsers::Pypi do
       expect(Bibliothecary::Parsers::Pypi.is_requirements_file('requirements-test.pip')).to be true
       expect(Bibliothecary::Parsers::Pypi.is_requirements_file('test-requirements.txt')).to be true
       expect(Bibliothecary::Parsers::Pypi.is_requirements_file('test-requirements.pip')).to be true
+      expect(Bibliothecary::Parsers::Pypi.is_requirements_file('test-invalid.pip')).to be false
+      expect(Bibliothecary::Parsers::Pypi.is_requirements_file('some-random-file.txt')).to be false
   end
 end


### PR DESCRIPTION
I wanted to add support for requirements files in the following format: `*-requirements.txt`.

It turns out this format is already support since the regular expression match function checks for match anywhere in the string and doesn't require input string to start with `require` (aka `^require`).

If nothing else, the tests should at least still be useful :)

