### PR TITLE
teach the nuget parser how to handle paket lockfiles

### DIFF
--- a/lib/bibliothecary/parsers/nuget.rb
+++ b/lib/bibliothecary/parsers/nuget.rb
@@ -2,6 +2,7 @@
 # Project.json
 # Project.lock.json
 # *.nuspec
+# paket.lock
 
 require 'ox'
 require 'json'
@@ -24,6 +25,9 @@ module Bibliothecary
         elsif filename.match(/^[A-Za-z0-9_-]+\.nuspec$/)
           xml = Ox.parse file_contents
           parse_nuspec(xml)
+        elsif filename.match(/paket\.lock$/)
+          # we want the lines, not the single string
+          parse_paket_lock(File.readlines(filename))
         else
           []
         end
@@ -33,7 +37,8 @@ module Bibliothecary
         [analyse_project_json(folder_path, file_list),
         analyse_project_lock_json(folder_path, file_list),
         analyse_packages_config(folder_path, file_list),
-        analyse_nuspec(folder_path, file_list)]
+        analyse_nuspec(folder_path, file_list),
+        analyse_paket_lock(folder_path, file_list)]
       end
 
       def self.analyse_project_json(folder_path, file_list)
@@ -88,6 +93,18 @@ module Bibliothecary
         }
       end
 
+      def self.analyse_paket_lock(folder_path, file_list)
+        path = file_list.find{|path| path.gsub(folder_path, '').gsub(/^\//, '').match(/Project\.lock\.json$/) }
+        return unless path
+
+        lines = File.readlines(path)
+        {
+          platform: PLATFORM_NAME,
+          path: path,
+          dependencies: parse_paket_lock(lines)
+        }
+      end
+
       def self.parse_project_json(manifest)
         manifest.fetch('dependencies',[]).map do |name, requirement|
           {
@@ -127,6 +144,19 @@ module Bibliothecary
             type: 'runtime'
           }
         end
+      end
+
+      def self.parse_paket_lock(lines)
+        package_version_re = /(?<name>.+)\s\((?<version>\d+\.\d+[\.\d+[\.\d+]*]*)\)/
+        packages = lines.select { |line| package_version_re.match(line) }.map { |line| package_version_re.match(line) }.map do |match|
+          {
+            name: match[:name],
+            version: match[:version],
+            type: 'runtime'
+          }
+        end
+        # we only have to enforce uniqueness by name because paket ensures that there is only the single version globally in the project
+        packages.uniq {|package| package[:name] }
       end
     end
   end

--- a/lib/bibliothecary/parsers/nuget.rb
+++ b/lib/bibliothecary/parsers/nuget.rb
@@ -26,8 +26,7 @@ module Bibliothecary
           xml = Ox.parse file_contents
           parse_nuspec(xml)
         elsif filename.match(/paket\.lock$/)
-          # we want the lines, not the single string
-          parse_paket_lock(File.readlines(filename))
+          parse_paket_lock(file_contents.split("\n"))
         else
           []
         end

--- a/lib/bibliothecary/parsers/nuget.rb
+++ b/lib/bibliothecary/parsers/nuget.rb
@@ -146,10 +146,10 @@ module Bibliothecary
       end
 
       def self.parse_paket_lock(lines)
-        package_version_re = /(?<name>.+)\s\((?<version>\d+\.\d+[\.\d+[\.\d+]*]*)\)/
+        package_version_re = /\s+(?<name>\S+)\s\((?<version>\d+\.\d+[\.\d+[\.\d+]*]*)\)/
         packages = lines.select { |line| package_version_re.match(line) }.map { |line| package_version_re.match(line) }.map do |match|
           {
-            name: match[:name],
+            name: match[:name].strip,
             version: match[:version],
             type: 'runtime'
           }

--- a/spec/bibliothecary_spec.rb
+++ b/spec/bibliothecary_spec.rb
@@ -22,12 +22,12 @@ describe Bibliothecary do
           Bibliothecary::Parsers::Maven,
           Bibliothecary::Parsers::Meteor,
           Bibliothecary::Parsers::NPM,
-          Bibliothecary::Parsers::Nuget,
           Bibliothecary::Parsers::Packagist,
           Bibliothecary::Parsers::Pub,
           Bibliothecary::Parsers::Pypi,
           Bibliothecary::Parsers::Rubygems,
-          Bibliothecary::Parsers::Shard
+          Bibliothecary::Parsers::Shard,
+          Bibliothecary::Parsers::Nuget
         ])
   end
 end

--- a/spec/fixtures/paket.lock
+++ b/spec/fixtures/paket.lock
@@ -1,0 +1,10 @@
+FRAMEWORK: >= NET40
+NUGET
+  remote: https://www.nuget.org/api/v2
+    Argu (2.1)
+    Mono.Cecil (0.9.6.1)
+    Chessie (0.5.1)
+      FSharp.Core
+    FSharp.Core (4.0.0.1) - redirects: force
+    Mono.Cecil (0.9.6.1)
+    Newtonsoft.Json (9.0.1) - redirects: force

--- a/spec/parsers/nuget_spec.rb
+++ b/spec/parsers/nuget_spec.rb
@@ -553,9 +553,9 @@ describe Bibliothecary::Parsers::Nuget do
     file = load_fixture('paket.lock')
     expect(Bibliothecary::Parsers::Nuget.parse('paket.lock', file)).to eq([
       {:name=>"Argu", :version=>"2.1", :type=>"runtime"},
+      {:name=>"Mono.Cecil", :version=>"0.9.6.1", :type=>"runtime"},
       {:name=>"Chessie", :version=>"0.5.1", :type=>"runtime"},
       {:name=>"FSharp.Core", :version=>"4.0.0.1", :type=>"runtime"},
-      {:name=>"Mono.Cecil", :version=>"0.9.6.1", :type=>"runtime"},
       {:name=>"Newtonsoft.Json", :version=>"9.0.1", :type=>"runtime"}
     ])
   end

--- a/spec/parsers/nuget_spec.rb
+++ b/spec/parsers/nuget_spec.rb
@@ -548,4 +548,15 @@ describe Bibliothecary::Parsers::Nuget do
       {:name=>"DotNetZip", :version=>"*", :type=>"runtime"}
     ])
   end
+
+  it 'parses dependencies from paket.lock' do
+    file = load_fixture('paket.lock')
+    expect(Bibliothecary::Parsers::Nuget.parse('paket.lock', file)).to eq([
+      {:name=>"Argu", :version=>"2.1", :type=>"runtime"},
+      {:name=>"Chessie", :version=>"0.5.1", :type=>"runtime"},
+      {:name=>"FSharp.Core", :version=>"4.0.0.1", :type=>"runtime"},
+      {:name=>"Mono.Cecil", :version=>"0.9.6.1", :type=>"runtime"},
+      {:name=>"Newtonsoft.Json", :version=>"9.0.1", :type=>"runtime"}
+    ])
+  end
 end


### PR DESCRIPTION
[Paket](http://fsprojects.github.io/Paket/) is an alternative Nuget client for the .net ecosystem that also handle git and file-based dependencies.  This PR teaches the Nuget parser how to read the [lockfiles](http://fsprojects.github.io/Paket/lock-file.html) generated by paket, which contain every dependency across the entire solution.

I'm not sure how detailed the dependency descriptions are, but this just handles the most common use case for paket: Nuget dependencies.  If there is enough demand I could expand the parser to learn about git, github, file, and group dependencies.