### PR TITLE
Adding manifest parser for gb (Golang vendoring tool)

### DIFF
--- a/lib/bibliothecary/parsers/go.rb
+++ b/lib/bibliothecary/parsers/go.rb
@@ -16,6 +16,9 @@ module Bibliothecary
         elsif filename.match(/^Godeps\/Godeps\.json$/)
           json = JSON.parse file_contents
           parse_godep_json(json)
+        elsif filename.match(/^vendor\/manifest$/)
+          json = JSON.parse file_contents
+          parse_gb_manifest(json)
         else
           []
         end
@@ -97,6 +100,16 @@ module Bibliothecary
           {
             name: dependency['name'],
             requirement: dependency['version'] || '*',
+            type: 'runtime'
+          }
+        end
+      end
+
+      def self.parse_gb_manifest(manifest)
+        manifest.fetch('dependencies',[]).map do |dependency|
+          {
+            name: dependency['importpath'],
+            requirement: dependency['revision'],
             type: 'runtime'
           }
         end

--- a/spec/fixtures/gb_manifest
+++ b/spec/fixtures/gb_manifest
@@ -1,0 +1,11 @@
+{
+	"version": 0,
+	"dependencies": [
+		{
+			"importpath": "github.com/gorilla/mux",
+			"repository": "https://github.com/gorilla/mux",
+			"revision": "9fa818a44c2bf1396a17f9d5a3c0f6dd39d2ff8e",
+			"branch": "master"
+		}
+	]
+}

--- a/spec/parsers/go_spec.rb
+++ b/spec/parsers/go_spec.rb
@@ -87,4 +87,14 @@ describe Bibliothecary::Parsers::Go do
        :type=>"runtime"}
     ])
   end
+
+  it 'parses dependencies from gb_manifest' do
+    file = load_fixture('gb_manifest')
+
+    expect(Bibliothecary::Parsers::Go.parse('vendor/manifest', file)).to eq([
+      {:name=>"github.com/gorilla/mux",
+       :requirement=>"9fa818a44c2bf1396a17f9d5a3c0f6dd39d2ff8e",
+       :type=>"runtime"}
+    ])
+  end
 end


### PR DESCRIPTION
Added gb manifest parsing to the `go.rb` parser, and associated tests.