### PR TITLE
Added support for csproj

### DIFF
--- a/lib/bibliothecary/parsers/nuget.rb
+++ b/lib/bibliothecary/parsers/nuget.rb
@@ -24,6 +24,10 @@ module Bibliothecary
             kind: 'manifest',
             parser: :parse_nuspec
           },
+          /^[A-Za-z0-9_-]+\.csproj$/ => {
+            kind: 'manifest',
+            parser: :parse_csproj
+          },
           /paket\.lock$/ => {
             kind: 'lockfile',
             parser: :parse_paket_lock
@@ -63,6 +67,20 @@ module Bibliothecary
             type: 'runtime'
           }
         end
+      rescue
+        []
+      end
+
+      def self.parse_csproj(file_contents)
+        manifest = Ox.parse file_contents
+        packages = manifest.locate('ItemGroup/PackageReference').map do |dependency|
+          {
+            name: dependency.Include,
+            version: dependency.Version,
+            type: 'runtime'
+          }
+        end
+        packages.uniq {|package| package[:name] }
       rescue
         []
       end

--- a/spec/fixtures/example.csproj
+++ b/spec/fixtures/example.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="1.1.0" />
+  </ItemGroup>
+</Project>

--- a/spec/parsers/nuget_spec.rb
+++ b/spec/parsers/nuget_spec.rb
@@ -548,6 +548,22 @@ describe Bibliothecary::Parsers::Nuget do
     })
   end
 
+  it 'parses dependencies from example.csproj' do
+    expect(described_class.analyse_contents('example.csproj', load_fixture('example.csproj'))).to eq({
+      :platform=>"nuget",
+      :path=>"example.csproj",
+      :dependencies=>[
+        {:name=>"Microsoft.AspNetCore", :version=>"1.1.1", :type=>"runtime"},
+        {:name=>"Microsoft.AspNetCore.Mvc", :version=>"1.1.2", :type=>"runtime"},
+        {:name=>"Microsoft.AspNetCore.StaticFiles", :version=>"1.1.1", :type=>"runtime"},
+        {:name=>"Microsoft.Extensions.Logging.Debug", :version=>"1.1.1", :type=>"runtime"},
+        {:name=>"Microsoft.Extensions.DependencyInjection", :version=>"1.1.1", :type=>"runtime"},
+        {:name=>"Microsoft.VisualStudio.Web.BrowserLink", :version=>"1.1.0", :type=>"runtime"}
+      ],
+      kind: 'manifest'
+    })
+  end
+
   it 'parses dependencies from example.nuspec' do
     expect(described_class.analyse_contents('example.nuspec', load_fixture('example.nuspec'))).to eq({
       :platform=>"nuget",
@@ -582,5 +598,6 @@ describe Bibliothecary::Parsers::Nuget do
     expect(described_class.match?('packages.config')).to be_truthy
     expect(described_class.match?('paket.lock')).to be_truthy
     expect(described_class.match?('example.nuspec')).to be_truthy
+    expect(described_class.match?('example.csproj')).to be_truthy
   end
 end


### PR DESCRIPTION
.NET Core 1 Preview used project.json, the final version uses .csproj in xml format. The actual parsing is pretty much like the packages.conf files for .NET Framework projects so the functionality is mostly reused. Tests added and passes.