### PR TITLE
Make test less fragile

### DIFF
--- a/spec/bibliothecary_spec.rb
+++ b/spec/bibliothecary_spec.rb
@@ -61,55 +61,24 @@ describe Bibliothecary do
   end
 
   it 'searches a folder for manifests and parses them' do
-    expect(described_class.analyse('./')).to eq(
+    analysis = described_class.analyse('./')
+    # empty out any dependencies to make the test more reliable.
+    # we test specific manifest parsers in the parsers specs
+    analysis.each do |a|
+      a[:dependencies] = []
+    end
+    expect(analysis).to eq(
       [{:platform=>"rubygems",
         :path=>"Gemfile",
-        :dependencies=>
-         [{:name=>"simplecov", :requirement=>">= 0", :type=>:development},
-          {:name=>"codeclimate-test-reporter",
-           :requirement=>"~> 1.0.0",
-           :type=>:development}],
+        :dependencies=>[],
          :kind => 'manifest'},
        {:platform=>"rubygems",
         :path=>"Gemfile.lock",
-        :dependencies=>
-         [{:name=>"bibliothecary", :requirement=>Bibliothecary::VERSION, :type=>"runtime"},
-          {:name=>"citrus", :requirement=>"3.0.2", :type=>"runtime"},
-          {:name=>"codeclimate-test-reporter",
-           :requirement=>"1.0.8",
-           :type=>"runtime"},
-          {:name=>"deb_control", :requirement=>"0.0.1", :type=>"runtime"},
-          {:name=>"diff-lcs", :requirement=>"1.3", :type=>"runtime"},
-          {:name=>"docile", :requirement=>"1.1.5", :type=>"runtime"},
-          {:name=>"ethon", :requirement=>"0.10.1", :type=>"runtime"},
-          {:name=>"ffi", :requirement=>"1.9.18", :type=>"runtime"},
-          {:name=>"json", :requirement=>"2.1.0", :type=>"runtime"},
-          {:name=>"librariesio-gem-parser", :requirement=>"1.0.0", :type=>"runtime"},
-          {:name=>"ox", :requirement=>"2.6.0", :type=>"runtime"},
-          {:name=>"rake", :requirement=>"12.0.0", :type=>"runtime"},
-          {:name=>"rspec", :requirement=>"3.6.0", :type=>"runtime"},
-          {:name=>"rspec-core", :requirement=>"3.6.0", :type=>"runtime"},
-          {:name=>"rspec-expectations", :requirement=>"3.6.0", :type=>"runtime"},
-          {:name=>"rspec-mocks", :requirement=>"3.6.0", :type=>"runtime"},
-          {:name=>"rspec-support", :requirement=>"3.6.0", :type=>"runtime"},
-          {:name=>"sdl4r", :requirement=>"0.9.11", :type=>"runtime"},
-          {:name=>"simplecov", :requirement=>"0.13.0", :type=>"runtime"},
-          {:name=>"simplecov-html", :requirement=>"0.10.2", :type=>"runtime"},
-          {:name=>"toml-rb", :requirement=>"1.0.0", :type=>"runtime"},
-          {:name=>"typhoeus", :requirement=>"1.1.2", :type=>"runtime"}],
+        :dependencies=>[],
         :kind => 'lockfile'},
        {:platform=>"rubygems",
         :path=>"bibliothecary.gemspec",
-        :dependencies=>
-         [{:name=>"toml-rb", :requirement=>"~> 1.0", :type=>:runtime},
-          {:name=>"librariesio-gem-parser", :requirement=>">= 0", :type=>:runtime},
-          {:name=>"ox", :requirement=>">= 0", :type=>:runtime},
-          {:name=>"typhoeus", :requirement=>">= 0", :type=>:runtime},
-          {:name=>"deb_control", :requirement=>">= 0", :type=>:runtime},
-          {:name=>"sdl4r", :requirement=>">= 0", :type=>:runtime},
-          {:name=>"bundler", :requirement=>"~> 1.11", :type=>:development},
-          {:name=>"rake", :requirement=>"~> 12.0", :type=>:development},
-          {:name=>"rspec", :requirement=>"~> 3.0", :type=>:development}],
+        :dependencies=>[],
         :kind => 'manifest'}])
   end
 end


### PR DESCRIPTION
This test was depending on the state of the repo pretty heavily
and needed to be updated whenever deps were updated. There's already
a good framework for testing specific parsers against fixtures so
we don't need to do that in this test also.

