### PR TITLE
Allow requirements like 2.0beta1 for python packages

### DIFF
--- a/lib/bibliothecary/parsers/pypi.rb
+++ b/lib/bibliothecary/parsers/pypi.rb
@@ -4,7 +4,7 @@ module Bibliothecary
       include Bibliothecary::Analyser
 
       INSTALL_REGEXP = /install_requires\s*=\s*\[([\s\S]*?)\]/
-      REQUIRE_REGEXP = /([a-zA-Z0-9]+[a-zA-Z0-9\-_\.]+)([><=\d\.,]+)?/
+      REQUIRE_REGEXP = /([a-zA-Z0-9]+[a-zA-Z0-9\-_\.]+)([><=\w\.,]+)?/
       REQUIREMENTS_REGEXP = /^#{REQUIRE_REGEXP}/
 
       def self.mapping

--- a/spec/fixtures/requirements.txt
+++ b/spec/fixtures/requirements.txt
@@ -8,3 +8,4 @@ chardet==1.0.1
 distribute==0.6.24
 gunicorn==0.14.2
 requests==0.11.1
+Django == 2.0beta1

--- a/spec/fixtures/setup.py
+++ b/spec/fixtures/setup.py
@@ -27,6 +27,7 @@ setup(name='political-memory',
         'python-dateutil>=2.4,<2.5',
         'pytz==2015.7',
         'django-suit',
+        'dummy==2.0beta1',
     ],
     extras_require={
         'testing': [

--- a/spec/parsers/pypi_spec.rb
+++ b/spec/parsers/pypi_spec.rb
@@ -33,7 +33,8 @@ describe Bibliothecary::Parsers::Pypi do
         {:name=>"ijson", :requirement=>">=2.2,<2.3", :type=>"runtime"},
         {:name=>"python-dateutil", :requirement=>">=2.4,<2.5", :type=>"runtime"},
         {:name=>"pytz", :requirement=>"==2015.7", :type=>"runtime"},
-        {:name=>"django-suit", :requirement=>"*", :type=>"runtime"}
+        {:name=>"django-suit", :requirement=>"*", :type=>"runtime"},
+        {:name=>"dummy", :requirement=>"==2.0beta1", :type=>"runtime"}
       ],
       kind: 'manifest'
     })
@@ -52,7 +53,8 @@ describe Bibliothecary::Parsers::Pypi do
         {:name=>"chardet", :requirement=>"==1.0.1", :type=>"runtime"},
         {:name=>"distribute", :requirement=>"==0.6.24", :type=>"runtime"},
         {:name=>"gunicorn", :requirement=>"==0.14.2", :type=>"runtime"},
-        {:name=>"requests", :requirement=>"==0.11.1", :type=>"runtime"}
+        {:name=>"requests", :requirement=>"==0.11.1", :type=>"runtime"},
+        {:name=>"Django", :requirement=>"==2.0beta1", :type=>"runtime"}
       ],
       kind: 'manifest'
     })


### PR DESCRIPTION
python packages can be versioned something like 2.0beta1. This
fixes bibliothecary to allow that type of version

Fixes https://github.com/librariesio/libraries.io/issues/1829
