### PR TITLE
Allow configuration of parser urls and ignored files at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ Search a directory for manifest files and parse the contents:
 Bibliothecary.analyse('./')
 ```
 
+There are a number of parsers that rely on web services to parse the file formats, those urls can be configured like so:
+
+```ruby
+Bibliothecary.configure do |config|
+  config.carthage_parser_host = 'http://my-carthage-parsing-service.com'
+end
+```
+
+All available config options are in: https://github.com/librariesio/bibliothecary/blob/master/lib/bibliothecary/configuration.rb
+
 ## Supported package manager file formats
 
 - npm

--- a/lib/bibliothecary.rb
+++ b/lib/bibliothecary.rb
@@ -1,5 +1,6 @@
 require "bibliothecary/version"
 require "bibliothecary/analyser"
+require "bibliothecary/configuration"
 
 Dir[File.expand_path('../bibliothecary/parsers/*.rb', __FILE__)].each do |file|
   require file
@@ -32,10 +33,22 @@ module Bibliothecary
   end
 
   def self.ignored_files
-    ['.git', 'node_modules', 'bower_components', 'spec/fixtures', 'vendor', 'dist']
+    configuration.ignored_files
   end
 
   def self.ignored_files_regex
     ignored_files.join('|')
+  end
+
+  class << self
+    attr_writer :configuration
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configure
+    yield(configuration)
   end
 end

--- a/lib/bibliothecary.rb
+++ b/lib/bibliothecary.rb
@@ -48,6 +48,10 @@ module Bibliothecary
     @configuration ||= Configuration.new
   end
 
+  def self.reset
+    @configuration = Configuration.new
+  end
+
   def self.configure
     yield(configuration)
   end

--- a/lib/bibliothecary/configuration.rb
+++ b/lib/bibliothecary/configuration.rb
@@ -1,0 +1,21 @@
+module Bibliothecary
+  class Configuration
+    attr_accessor :ignored_files
+    attr_accessor :carthage_parser_host
+    attr_accessor :clojars_parser_host
+    attr_accessor :mix_parser_host
+    attr_accessor :gradle_parser_host
+    attr_accessor :yarn_parser_host
+    attr_accessor :swift_parser_host
+
+    def initialize
+      @ignored_files = ['.git', 'node_modules', 'bower_components', 'spec/fixtures', 'vendor', 'dist']
+      @carthage_parser_host = 'https://carthage.libraries.io'
+      @clojars_parser_host  = 'https://clojars.libraries.io'
+      @mix_parser_host      = 'https://mix.libraries.io'
+      @gradle_parser_host   = 'https://gradle-parser.libraries.io'
+      @yarn_parser_host     = 'https://yarn-parser.libraries.io'
+      @swift_parser_host    = 'http://swift.libraries.io'
+    end
+  end
+end

--- a/lib/bibliothecary/parsers/carthage.rb
+++ b/lib/bibliothecary/parsers/carthage.rb
@@ -33,7 +33,7 @@ module Bibliothecary
       end
 
       def self.map_dependencies(manifest, path)
-        response = Typhoeus.post("https://carthage.libraries.io/#{path}", params: {body: manifest})
+        response = Typhoeus.post("#{Bibliothecary.configuration.carthage_parser_host}/#{path}", params: {body: manifest})
         json = JSON.parse(response.body)
 
         json.map do |dependency|

--- a/lib/bibliothecary/parsers/clojars.rb
+++ b/lib/bibliothecary/parsers/clojars.rb
@@ -16,7 +16,7 @@ module Bibliothecary
       end
 
       def self.parse_manifest(manifest)
-        response = Typhoeus.post("https://clojars.libraries.io/project.clj", body: manifest)
+        response = Typhoeus.post("#{Bibliothecary.configuration.clojars_parser_host}/project.clj", body: manifest)
         json = JSON.parse response.body
         index = json.index("dependencies")
 

--- a/lib/bibliothecary/parsers/hex.rb
+++ b/lib/bibliothecary/parsers/hex.rb
@@ -19,7 +19,7 @@ module Bibliothecary
       end
 
       def self.parse_mix(manifest)
-        response = Typhoeus.post("https://mix.libraries.io/", body: manifest)
+        response = Typhoeus.post("#{Bibliothecary.configuration.mix_parser_host}/", body: manifest)
         json = JSON.parse response.body
 
         json.map do |name, version|
@@ -32,7 +32,7 @@ module Bibliothecary
       end
 
       def self.parse_mix_lock(manifest)
-        response = Typhoeus.post("https://mix.libraries.io/lock", body: manifest)
+        response = Typhoeus.post("#{Bibliothecary.configuration.mix_parser_host}/lock", body: manifest)
         json = JSON.parse response.body
 
         json.map do |name, info|

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -56,7 +56,7 @@ module Bibliothecary
       end
 
       def self.parse_gradle(manifest)
-        response = Typhoeus.post("https://gradle-parser.libraries.io/parse", body: manifest)
+        response = Typhoeus.post("#{Bibliothecary.configuration.gradle_parser_host}/parse", body: manifest)
         json = JSON.parse(response.body)
         return [] unless json['dependencies']
         json['dependencies'].map do |dependency|

--- a/lib/bibliothecary/parsers/npm.rb
+++ b/lib/bibliothecary/parsers/npm.rb
@@ -55,7 +55,7 @@ module Bibliothecary
       end
 
       def self.parse_yarn_lock(file_contents)
-        response = Typhoeus.post("https://yarn-parser.libraries.io/parse", body: file_contents)
+        response = Typhoeus.post("#{Bibliothecary.configuration.yarn_parser_host}/parse", body: file_contents)
         return [] unless response.response_code == 200
         json = JSON.parse(response.body, symbolize_names: true)
         json.uniq.map do |dep|

--- a/lib/bibliothecary/parsers/swift_pm.rb
+++ b/lib/bibliothecary/parsers/swift_pm.rb
@@ -13,7 +13,7 @@ module Bibliothecary
       end
 
       def self.parse_package_swift(manifest)
-        response = Typhoeus.post("http://swift.libraries.io/to-json", body: manifest)
+        response = Typhoeus.post("#{Bibliothecary.configuration.swift_parser_host}/to-json", body: manifest)
         json = JSON.parse(response.body)
         json["dependencies"].map do |dependency|
           name = dependency['url'].gsub(/^https?:\/\//, '').gsub(/\.git$/,'')

--- a/spec/bibliothecary_spec.rb
+++ b/spec/bibliothecary_spec.rb
@@ -81,4 +81,32 @@ describe Bibliothecary do
         :dependencies=>[],
         :kind => 'manifest'}])
   end
+
+  it 'allows customization of config options' do
+    Bibliothecary.configure do |config|
+      config.ignored_files = ['foobar']
+    end
+
+    expect(Bibliothecary.ignored_files).to eq(['foobar'])
+
+    Bibliothecary.reset
+  end
+
+  it 'allows customization of config options' do
+    Bibliothecary.configure do |config|
+      config.ignored_files = ['foobar']
+    end
+
+    expect(Bibliothecary.ignored_files).to eq(['foobar'])
+  end
+
+  it 'allows resetting of config options' do
+    Bibliothecary.configure do |config|
+      config.carthage_parser_host = 'http://foobar.com'
+    end
+
+    Bibliothecary.reset
+
+    expect(Bibliothecary.configuration.carthage_parser_host).to eq('https://carthage.libraries.io')
+  end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Bibliothecary::Configuration do
+  let(:config) { described_class.new }
+
+  it 'should have a default list of ignored files' do
+    expect(config.ignored_files).to eq(['.git', 'node_modules', 'bower_components', 'spec/fixtures', 'vendor', 'dist'])
+  end
+
+  it 'should have a default host for carthage parser' do
+    expect(config.carthage_parser_host).to eq('https://carthage.libraries.io')
+  end
+
+  it 'should have a default host for clojars parser' do
+    expect(config.clojars_parser_host).to eq('https://clojars.libraries.io')
+  end
+
+  it 'should have a default host for mix parser' do
+    expect(config.mix_parser_host).to eq('https://mix.libraries.io')
+  end
+
+  it 'should have a default host for gradle parser' do
+    expect(config.gradle_parser_host).to eq('https://gradle-parser.libraries.io')
+  end
+
+  it 'should have a default host for yarn parser' do
+    expect(config.yarn_parser_host).to eq('https://yarn-parser.libraries.io')
+  end
+
+  it 'should have a default host for swift parser' do
+    expect(config.swift_parser_host).to eq('http://swift.libraries.io')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,3 +7,9 @@ require 'bibliothecary'
 def load_fixture(name)
   File.open("spec/fixtures/#{name}").read
 end
+
+RSpec.configure do |config|
+  config.after(:each) do
+    Bibliothecary.reset
+  end
+end


### PR DESCRIPTION
This will make using bibliothecary inside of docker, behind a firewall or just without depending on Libraries.io infrastructure much easier to do. 

Fixes https://github.com/librariesio/bibliothecary/issues/160

Example:
```ruby
Bibliothecary.configure do |config|
  config.mix_parser_host = 'http://my-mix-parser-web-service.com'
end
```

Still needs: 
- [x] Documentation
- [x] Tests