### PR TITLE
Report error text

### DIFF
--- a/lib/bibliothecary.rb
+++ b/lib/bibliothecary.rb
@@ -24,7 +24,7 @@ module Bibliothecary
   end
 
   def self.analyse_file(file_path, contents)
-    package_managers.map do |pm|
+    package_managers.select { |pm| pm.match?(file_path, contents) }.map do |pm|
       pm.analyse_contents(file_path, contents)
     end.flatten.uniq.compact
   end

--- a/lib/bibliothecary/analyser.rb
+++ b/lib/bibliothecary/analyser.rb
@@ -34,7 +34,7 @@ module Bibliothecary
             end
           end
         end
-        return []
+        raise Bibliothecary::FileParsingError.new("No parser for this file type", filename)
       end
 
       def match?(filename, contents=nil)

--- a/lib/bibliothecary/exceptions.rb
+++ b/lib/bibliothecary/exceptions.rb
@@ -6,4 +6,13 @@ module Bibliothecary
       super(msg)
     end
   end
+
+  class FileParsingError < StandardError
+    attr_accessor :filename
+    def initialize(msg, filename)
+      @filename = filename
+      msg = "#{filename}: #{msg}" unless msg.include?(filename)
+      super("#{msg}")
+    end
+  end
 end

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -37,8 +37,6 @@ module Bibliothecary
             type: 'runtime'
           }
         end
-      rescue
-        []
       end
 
       def self.ivy_report?(file_contents)

--- a/spec/fixtures/broken/pom.xml
+++ b/spec/fixtures/broken/pom.xml
@@ -1,0 +1,1 @@
+This is not an xml file

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -86,6 +86,12 @@ describe Bibliothecary::Parsers::Maven do
     })
   end
 
+  it 'raises FileParsingError on a broken pom.xml' do
+    expect {
+      described_class.parse_file('pom.xml', load_fixture('broken/pom.xml'))
+    }.to raise_error(Bibliothecary::FileParsingError, "pom.xml: invalid format, expected < at line 1, column 1 [parse.c:147]")
+  end
+
   it 'parses dependencies from pom2.xml' do
     expect(described_class.analyse_contents('pom.xml', load_fixture('pom2.xml'))).to eq({
       :platform=>"maven",
@@ -209,14 +215,15 @@ describe Bibliothecary::Parsers::Maven do
       path: "missing_info.xml",
       dependencies: nil,
       kind: 'lockfile',
-      success: false
+      success: false,
+      error_message: "missing_info.xml: ivy-report document lacks <info> element"
     })
   end
 
-  it 'raises error on a broken ivy report' do
+  it 'raises FileParsingError on a broken ivy report' do
     expect {
       described_class.parse_file('missing_info.xml', load_fixture('ivy_reports/missing_info.xml'))
-    }.to raise_error(StandardError, "ivy-report document lacks <info> element")
+    }.to raise_error(Bibliothecary::FileParsingError, "missing_info.xml: ivy-report document lacks <info> element")
   end
 
   it 'returns [] on an xml file with no ivy_report' do

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -226,12 +226,16 @@ describe Bibliothecary::Parsers::Maven do
     }.to raise_error(Bibliothecary::FileParsingError, "missing_info.xml: ivy-report document lacks <info> element")
   end
 
-  it 'returns [] on an xml file with no ivy_report' do
-    expect(described_class.parse_file('non_ivy_report.xml', load_fixture('ivy_reports/non_ivy_report.xml'))).to eq([])
+  it 'raises FileParsingError on an xml file with no ivy_report' do
+    expect {
+      described_class.parse_file('non_ivy_report.xml', load_fixture('ivy_reports/non_ivy_report.xml'))
+    }.to raise_error(Bibliothecary::FileParsingError, "non_ivy_report.xml: No parser for this file type")
   end
 
   it 'returns [] on an .xml file with bad syntax' do
-    expect(described_class.parse_file('invalid_syntax.xml', load_fixture('ivy_reports/invalid_syntax.xml'))).to eq([])
+    expect {
+      described_class.parse_file('invalid_syntax.xml', load_fixture('ivy_reports/invalid_syntax.xml'))
+    }.to raise_error(Bibliothecary::FileParsingError, "invalid_syntax.xml: No parser for this file type")
   end
 
   it 'can determine kind on an ivy report with no contents specified' do


### PR DESCRIPTION
This cleans up error handling to make a bit more sense and gets the message from any exception thrown into the returned analysis hash.