### PR TITLE
Adjust how we handle absolute/relative paths and file contents

### DIFF
--- a/lib/bibliothecary.rb
+++ b/lib/bibliothecary.rb
@@ -2,6 +2,7 @@ require "bibliothecary/version"
 require "bibliothecary/analyser"
 require "bibliothecary/configuration"
 require "bibliothecary/exceptions"
+require "bibliothecary/file_info"
 require "find"
 
 Dir[File.expand_path('../bibliothecary/parsers/*.rb', __FILE__)].each do |file|
@@ -10,15 +11,20 @@ end
 
 module Bibliothecary
   def self.analyse(path)
-    file_list = load_file_list(path)
-    package_managers.map{|pm| pm.analyse(path, file_list) }.flatten.compact
+    info_list = load_file_info_list(path)
+    package_managers.map{|pm| pm.analyse_file_info(info_list) }.flatten.compact
   end
 
+  # deprecated; use load_file_info_list.
   def self.load_file_list(path)
+    load_file_info_list(path).map { |info| info.absolute_path }
+  end
+
+  def self.load_file_info_list(path)
     file_list = []
     Find.find(path) do |subpath|
       Find.prune if FileTest.directory?(subpath) && ignored_dirs.include?(File.basename(subpath))
-      file_list.push(subpath) if FileTest.file?(subpath)
+      file_list.push(FileInfo.new(path, subpath)) if FileTest.file?(subpath)
     end
     file_list
   end
@@ -29,10 +35,17 @@ module Bibliothecary
     end.flatten.uniq.compact
   end
 
+  # this skips manifests sometimes because it doesn't look at file
+  # contents and can't establish from only regexes that the thing
+  # is a manifest. We exclude rather than include ambiguous filenames
+  # because this API is used by libraries.io and we don't want to
+  # download all .xml files from GitHub.
   def self.identify_manifests(file_list)
     allowed_file_list = file_list.reject{|f| f.start_with?(*ignored_dirs) }
     package_managers.map do |pm|
       allowed_file_list.select do |file_path|
+        # this is a call to match? without file contents, which will skip
+        # ambiguous filenames that are only possibly a manifest
         pm.match?(file_path)
       end
     end.flatten.uniq.compact

--- a/lib/bibliothecary.rb
+++ b/lib/bibliothecary.rb
@@ -17,7 +17,7 @@ module Bibliothecary
 
   # deprecated; use load_file_info_list.
   def self.load_file_list(path)
-    load_file_info_list(path).map { |info| info.absolute_path }
+    load_file_info_list(path).map { |info| info.full_path }
   end
 
   def self.load_file_info_list(path)

--- a/lib/bibliothecary/file_info.rb
+++ b/lib/bibliothecary/file_info.rb
@@ -2,33 +2,46 @@ require 'pathname'
 
 module Bibliothecary
   class FileInfo
-    def folder_path
-      @folder_pathname.to_path
-    end
-
-    def absolute_path
-      @absolute_pathname.to_path
-    end
-
-    def relative_path
-      @relative_pathname.to_path
-    end
+    attr_reader :folder_path
+    attr_reader :relative_path
+    attr_reader :full_path
 
     def contents
-      @contents ||= @absolute_pathname.open.read
+      @contents ||=
+        begin
+          if @folder_path.nil?
+            # if we have no folder_path then we aren't dealing with a
+            # file that's actually on the filesystem
+            nil
+          else
+            File.open(@full_path).read
+          end
+        end
     end
 
     # If the FileInfo represents an actual file on disk,
     # the contents can be nil and lazy-loaded; we allow
     # contents to be passed in here to allow pulling them
     # from somewhere other than the disk.
-    def initialize(folder_path, absolute_path, contents = nil)
+    def initialize(folder_path, full_path, contents = nil)
       # Note that cleanpath does NOT touch the filesystem,
       # leaving the lazy-load of file contents as the only
       # time we touch the filesystem.
-      @folder_pathname = Pathname.new(folder_path).cleanpath
-      @absolute_pathname = Pathname.new(absolute_path).cleanpath
-      @relative_pathname = @absolute_pathname.relative_path_from(@folder_pathname)
+
+      full_pathname = Pathname.new(full_path)
+      @full_path = full_pathname.cleanpath.to_path
+
+      if folder_path.nil?
+        # this is the case where we e.g. have filenames from the GitHub API
+        # and don't have a local folder
+        @folder_path = nil
+        @relative_path = @full_path
+      else
+        folder_pathname = Pathname.new(folder_path)
+        @folder_path = folder_pathname.cleanpath.to_path
+        @relative_path = full_pathname.relative_path_from(folder_pathname).cleanpath.to_path
+      end
+
       @contents = contents
     end
   end

--- a/lib/bibliothecary/file_info.rb
+++ b/lib/bibliothecary/file_info.rb
@@ -1,0 +1,35 @@
+require 'pathname'
+
+module Bibliothecary
+  class FileInfo
+    def folder_path
+      @folder_pathname.to_path
+    end
+
+    def absolute_path
+      @absolute_pathname.to_path
+    end
+
+    def relative_path
+      @relative_pathname.to_path
+    end
+
+    def contents
+      @contents ||= @absolute_pathname.open.read
+    end
+
+    # If the FileInfo represents an actual file on disk,
+    # the contents can be nil and lazy-loaded; we allow
+    # contents to be passed in here to allow pulling them
+    # from somewhere other than the disk.
+    def initialize(folder_path, absolute_path, contents = nil)
+      # Note that cleanpath does NOT touch the filesystem,
+      # leaving the lazy-load of file contents as the only
+      # time we touch the filesystem.
+      @folder_pathname = Pathname.new(folder_path).cleanpath
+      @absolute_pathname = Pathname.new(absolute_path).cleanpath
+      @relative_pathname = @absolute_pathname.relative_path_from(@folder_pathname)
+      @contents = contents
+    end
+  end
+end

--- a/spec/bibliothecary_spec.rb
+++ b/spec/bibliothecary_spec.rb
@@ -62,7 +62,12 @@ describe Bibliothecary do
     Bibliothecary.configure do |config|
       config.ignored_dirs.push("fixtures")
     end
-    analysis = described_class.analyse('./')
+    # If we run the analysis in pwd, confusion about absolute vs.
+    # relative paths is concealed because both work
+    orig_pwd = Dir.pwd
+    analysis = Dir.chdir("/") do
+      described_class.analyse(orig_pwd)
+    end
     # empty out any dependencies to make the test more reliable.
     # we test specific manifest parsers in the parsers specs
     analysis.each do |a|
@@ -90,7 +95,12 @@ describe Bibliothecary do
   end
 
   it 'handles a complicated folder with many manifests', :vcr do
-    analysis = described_class.analyse('./spec/fixtures/multimanifest_dir')
+    # If we run the analysis in pwd, confusion about absolute vs.
+    # relative paths is concealed because both work
+    orig_pwd = Dir.pwd
+    analysis = Dir.chdir("/") do
+      described_class.analyse(File.join(orig_pwd, 'spec/fixtures/multimanifest_dir'))
+    end
     # empty out any dependencies to make the test more reliable.
     # we test specific manifest parsers in the parsers specs
     analysis.each do |a|
@@ -98,11 +108,17 @@ describe Bibliothecary do
     end
     expect(analysis).to eq(
       [{:platform=>"maven",
+        :path=>"com.example-hello_2.12-compile.xml",
+        :dependencies=>[],
+        :kind=>"lockfile",
+        :success=>true,
+        :related_paths=>["pom.xml"]},
+       {:platform=>"maven",
         :path=>"pom.xml",
         :dependencies=>[],
         :kind=>"manifest",
         success: true,
-        :related_paths=>[]},
+        :related_paths=>["com.example-hello_2.12-compile.xml"]},
        {:platform=>"npm",
         :path=>"package-lock.json",
         :dependencies=>[],

--- a/spec/fixtures/multimanifest_dir/com.example-hello_2.12-compile.xml
+++ b/spec/fixtures/multimanifest_dir/com.example-hello_2.12-compile.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="ivy-report.xsl"?>
+<ivy-report version="1.0">
+	<info
+		organisation="com.example"
+		module="hello_2.12"
+		revision="0.1.0-SNAPSHOT"
+		conf="compile"
+		confs="compile, runtime, test, provided, optional, compile-internal, runtime-internal, test-internal, plugin, pom, scala-tool"
+		date="20181009145225"/>
+	<dependencies>
+		<module organisation="org.scala-lang" name="scala-library">
+			<revision name="2.12.5" status="release" pubdate="20180316094746" resolver="sbt-chain" artresolver="sbt-chain" homepage="http://www.scala-lang.org/" extra-info.apiURL="http://www.scala-lang.org/api/2.12.5/" downloaded="false" searched="false" default="false" conf="default, compile, runtime, default(compile), master" position="0">
+				<license name="BSD 3-Clause" url="http://www.scala-lang.org/license.html"/>
+				<metadata-artifact status="no" details="" size="2653" time="0" location="/home/hp/.ivy2/cache/org.scala-lang/scala-library/ivy-2.12.5.xml" searched="false" origin-is-local="false" origin-location="https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.5/scala-library-2.12.5.pom"/>
+				<caller organisation="com.example" name="hello_2.12" conf="compile" rev="2.12.5" rev-constraint-default="2.12.5" rev-constraint-dynamic="2.12.5" callerrev="0.1.0-SNAPSHOT"/>
+				<artifacts>
+					<artifact name="scala-library" type="jar" ext="jar" status="no" details="" size="5263467" time="0" location="/home/hp/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.12.5.jar">
+						<origin-location is-local="false" location="https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.5/scala-library-2.12.5.jar"/>
+					</artifact>
+				</artifacts>
+			</revision>
+		</module>
+	</dependencies>
+</ivy-report>

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -238,8 +238,8 @@ describe Bibliothecary::Parsers::Maven do
     }.to raise_error(Bibliothecary::FileParsingError, "invalid_syntax.xml: No parser for this file type")
   end
 
-  it 'can determine kind on an ivy report with no contents specified' do
-    expect(described_class.determine_kind(fixture_path('ivy_reports/com.example-hello_2.12-compile.xml'))).to eq("lockfile")
+  it 'cannot determine kind on an ivy report with no contents specified' do
+    expect(described_class.determine_kind(fixture_path('ivy_reports/com.example-hello_2.12-compile.xml'))).to be(nil)
   end
 
   it 'cannot determine kind on an ivy report with no contents available' do
@@ -253,8 +253,11 @@ describe Bibliothecary::Parsers::Maven do
     expect(described_class.match?('build.gradle')).to be_truthy
     # since the file doesn't really exist, we can't say it's a manifest file
     expect(described_class.match?('whatever.xml')).to be_falsey
-    # but if it's a real file we should be able to identify it has <ivy-report> in it
-    expect(described_class.match?(fixture_path('ivy_reports/com.example-hello_2.12-compile.xml'))).to be_truthy
+    # but if it's a real file with contents we should be able to identify it has <ivy-report> in it
+    expect(described_class.match?(fixture_path('ivy_reports/com.example-hello_2.12-compile.xml'),
+                                  load_fixture('ivy_reports/com.example-hello_2.12-compile.xml'))).to be_truthy
+    # but if it's a real file without contents we should not be able to identify it has <ivy-report> in it
+    expect(described_class.match?(fixture_path('ivy_reports/com.example-hello_2.12-compile.xml'))).to be_falsey
     # not an ivy-report but ends in xml
     expect(described_class.match?(fixture_path('ivy_reports/non_ivy_report.xml'))).to be_falsey
     # not an ivy-report because bad xml


### PR DESCRIPTION
What's happening here:
  * in libraries.io, when scanning repositories, we get a bunch of relative path names from GitHub, filter those by regex, and then download only some of them to analyze the contents
  * but in Bibliothecary.analyse, we have an actual local directory which means
    - we can look at the file contents
    - to look at the file contents we need an open-able path name which can be relative to pwd but NOT relative to the project directory which may not be pwd

In this PR I'm creating a FileInfo object which has "what we know about a file" and lazy-loads the contents the first time we try to look at them. The project folder path can be nil and the contents can be nil, for the "we just have relative paths from GitHub" case.

FileInfo has three purposes
  * lazy-load contents
  * avoid passing 3-4 parameters (full path, relative path, contents) to every method
  * do all canonicalization of paths in one spot
  * avoid having parameters called "filename" or "path" which aren't clear about whether they are relative, and if relative, relative to pwd vs. project folder

This seems sort of messy, in part because of trying to keep back compat, but also because of the two pretty different ways we use the API (to process relative names from GitHub vs. to process a local directory). I dunno.