### PR TITLE
Avoid root method on result of 0x.parse_file_contents

### DIFF
--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -41,13 +41,19 @@ module Bibliothecary
 
       def self.ivy_report?(file_contents)
         doc = Ox.parse file_contents
-        doc&.root&.value == 'ivy-report'
+        root = doc&.locate("ivy-report")&.first
+        return !root.nil?
+      rescue Exception => e
+        # We rescue exception here since native libs can throw a non-StandardError
+        # We don't want to throw errors during the matching phase, only during
+        # parsing after we match.
+        false
       end
 
       def self.parse_ivy_report(file_contents)
         doc = Ox.parse file_contents
-        root = doc.root
-        raise "ivy-report document does not have ivy-report at the root" if root.value != "ivy-report"
+        root = doc.locate("ivy-report").first
+        raise "ivy-report document does not have ivy-report at the root" if root.nil?
         info = doc.locate("ivy-report/info").first
         raise "ivy-report document lacks <info> element" if info.nil?
         type = info.attributes[:conf]


### PR DESCRIPTION
Use locate() instead. Not sure why/when root is missing,
but apparently it can be in production.

Also, catch any exceptions in ivy_report? matcher,
since we aren't going to handle them at that point.
This does mean we may have worse error messages
when a file doesn't have ivy-report at the root,
since we won't even get around to trying to parse it.

Future solution might be to have a mode where
all files are expected to be parseable (and we might
not even do the match first).
