### PR TITLE
Add ignored_files and fixes to ignored_dirs

### DIFF
--- a/lib/bibliothecary.rb
+++ b/lib/bibliothecary.rb
@@ -73,13 +73,7 @@ module Bibliothecary
   # because this API is used by libraries.io and we don't want to
   # download all .xml files from GitHub.
   def self.identify_manifests(file_list)
-    ignored_dirs_with_slash = ignored_dirs.map do |d|
-      if d.end_with?("/")
-        d
-      else
-        d + "/"
-      end
-    end
+    ignored_dirs_with_slash = ignored_dirs.map { |d| if d.end_with?("/") then d else d + "/" end }
     allowed_file_list = file_list.reject do |f|
       ignored_dirs.include?(f) || f.start_with?(*ignored_dirs_with_slash)
     end

--- a/lib/bibliothecary/configuration.rb
+++ b/lib/bibliothecary/configuration.rb
@@ -1,6 +1,7 @@
 module Bibliothecary
   class Configuration
     attr_accessor :ignored_dirs
+    attr_accessor :ignored_files
     attr_accessor :carthage_parser_host
     attr_accessor :clojars_parser_host
     attr_accessor :mix_parser_host
@@ -11,6 +12,7 @@ module Bibliothecary
 
     def initialize
       @ignored_dirs = ['.git', 'node_modules', 'bower_components', 'vendor', 'dist']
+      @ignored_files = []
       @carthage_parser_host = 'https://carthage.libraries.io'
       @clojars_parser_host  = 'https://clojars.libraries.io'
       @mix_parser_host      = 'https://mix.libraries.io'


### PR DESCRIPTION
* there's now an ignored_files configuration option
 * ignored_dirs now matches entire relative path not only basename
 * test for ignored_dirs actually works
 * in identify_manifests, ignoring "foo" no longer ignores "foobar",
   but still ignores "foo/bar"

ignored_dirs previously matched the dir anywhere that the basename
occurred in the hierarchy, and had to be a single filename not a path.
This was in the "we have a local checkout" case.
But when identifying manifests without a local checkout, it
required the dir to be at the start of the path.

It now consistently works the same way, you _can_ ignore `spec/fixtures`
but ignoring only `fixtures` won't match that. This isn't compatible
with one of the cases, but seems more expected overall?

ignored_dirs test had a test that always succeeded even if ignored_dirs
didn't work, fixed that.

Added an ignored_files feature to allow ignoring certain files.