### PR TITLE
Don't use regexes while matching paths

### DIFF
--- a/lib/bibliothecary/analyser.rb
+++ b/lib/bibliothecary/analyser.rb
@@ -209,7 +209,12 @@ module Bibliothecary
         manifest.dependencies.inject([]) do |deps, dep|
           deps.push({
             name: dep.name,
-            requirement: dep.requirement.to_s,
+            requirement: dep
+              .requirement
+              .requirements
+              .sort_by(&:last)
+              .map { |op, version| "#{op} #{version}" }
+              .join(", "),
             type: dep.type
           })
         end.uniq

--- a/lib/bibliothecary/parsers/bower.rb
+++ b/lib/bibliothecary/parsers/bower.rb
@@ -7,7 +7,7 @@ module Bibliothecary
 
       def self.mapping
         {
-          /(^bower\.json$|.*\/bower\.json$)/ => {
+          match_filename("bower.json") => {
             kind: 'manifest',
             parser: :parse_manifest
           }

--- a/lib/bibliothecary/parsers/cargo.rb
+++ b/lib/bibliothecary/parsers/cargo.rb
@@ -7,11 +7,11 @@ module Bibliothecary
 
       def self.mapping
         {
-          /(^Cargo.toml$|.*\/Cargo.toml$)/ => {
+          match_filename("Cargo.toml") => {
             kind: 'manifest',
             parser: :parse_manifest
           },
-          /(^Cargo\.lock$|.*\/Cargo\.lock$)/ => {
+          match_filename("Cargo.lock") => {
             kind: 'lockfile',
             parser: :parse_lockfile
           }

--- a/lib/bibliothecary/parsers/carthage.rb
+++ b/lib/bibliothecary/parsers/carthage.rb
@@ -5,15 +5,15 @@ module Bibliothecary
 
       def self.mapping
         {
-          /(^Cartfile$|.*\/Cartfile$)/ => {
+          match_filename("Cartfile") => {
             kind: 'manifest',
             parser: :parse_cartfile
           },
-          /(^Cartfile\.private$|.*\/Cartfile\.private$)/ => {
+          match_filename("Cartfile.private") => {
             kind: 'manifest',
             parser: :parse_cartfile_private
           },
-          /(^Cartfile\.resolved$|.*\/Cartfile\.resolved$)/ => {
+          match_filename("Cartfile.resolved") => {
             kind: 'lockfile',
             parser: :parse_cartfile_resolved
           }

--- a/lib/bibliothecary/parsers/clojars.rb
+++ b/lib/bibliothecary/parsers/clojars.rb
@@ -8,7 +8,7 @@ module Bibliothecary
 
       def self.mapping
         {
-          /(^project\.clj$|.*\/project\.clj$)/ => {
+          match_filename("project.clj") => {
             kind: 'manifest',
             parser: :parse_manifest
           }

--- a/lib/bibliothecary/parsers/cocoapods.rb
+++ b/lib/bibliothecary/parsers/cocoapods.rb
@@ -11,20 +11,20 @@ module Bibliothecary
 
       def self.mapping
         {
-          /(^Podfile$|.*\/Podfile$)/ => {
+          match_filename("Podfile") => {
             kind: 'manifest',
             parser: :parse_podfile
           },
-          /(^[A-Za-z0-9_-]+\.podspec$|.*\/[A-Za-z0-9_-]+\.podspec$)/ => {
+          match_extension(".podspec") => {
             kind: 'manifest',
             parser: :parse_podspec,
             can_have_lockfile: false
           },
-          /(^Podfile\.lock$|.*\/Podfile\.lock$)/ => {
+          match_filename("Podfile.lock") => {
             kind: 'lockfile',
             parser: :parse_podfile_lock
           },
-          /(^[A-Za-z0-9_-]+\.podspec.json$|.*\/[A-Za-z0-9_-]+\.podspec.json$)/ => {
+          match_extension(".podspec.json") => {
             kind: 'manifest',
             parser: :parse_json_manifest,
             can_have_lockfile: false

--- a/lib/bibliothecary/parsers/cpan.rb
+++ b/lib/bibliothecary/parsers/cpan.rb
@@ -8,11 +8,11 @@ module Bibliothecary
 
       def self.mapping
         {
-          /(^META\.json$|.*\/META\.json$)/i => {
+          match_filename("META.json", case_insensitive: true) => {
             kind: 'manifest',
             parser: :parse_json_manifest
           },
-          /(^META\.yml$|.*\/META.yml$)/i => {
+          match_filename("META.yml", case_insensitive: true) => {
             kind: 'manifest',
             parser: :parse_yaml_manifest
           }

--- a/lib/bibliothecary/parsers/cran.rb
+++ b/lib/bibliothecary/parsers/cran.rb
@@ -9,7 +9,7 @@ module Bibliothecary
 
       def self.mapping
         {
-          /(^DESCRIPTION$|.*\/DESCRIPTION$)/i => {
+          match_filename("DESCRIPTION", case_insensitive: true) => {
             kind: 'manifest',
             parser: :parse_description
           }

--- a/lib/bibliothecary/parsers/dub.rb
+++ b/lib/bibliothecary/parsers/dub.rb
@@ -8,11 +8,11 @@ module Bibliothecary
 
       def self.mapping
         {
-          /(^dub\.json$|.*\/dub\.json$)/ => {
+          match_filename("dub.json") => {
             kind: 'manifest',
             parser: :parse_json_runtime_manifest
           },
-          /(^dub\.sdl$|.*\/dub\.sdl$)/ => {
+          match_filename("dub.sdl") => {
             kind: 'manifest',
             parser: :parse_sdl_manifest
           }

--- a/lib/bibliothecary/parsers/elm.rb
+++ b/lib/bibliothecary/parsers/elm.rb
@@ -7,11 +7,11 @@ module Bibliothecary
 
       def self.mapping
         {
-          /(^elm-package\.json$|^elm_dependencies\.json$|.*\/elm-package\.json$|.*\/elm_dependencies\.json$)/ => {
+          match_filenames("elm-package.json", "elm_dependencies.json") => {
             kind: 'manifest',
             parser: :parse_json_runtime_manifest
           },
-          /(^elm-stuff\/exact-dependencies\.json$|.*\/elm-stuff\/exact-dependencies\.json$)/ => {
+          match_filename("elm-stuff/exact-dependencies.json") => {
             kind: 'lockfile',
             parser: :parse_json_lock
           }

--- a/lib/bibliothecary/parsers/go.rb
+++ b/lib/bibliothecary/parsers/go.rb
@@ -10,35 +10,35 @@ module Bibliothecary
 
       def self.mapping
         {
-          /(^glide\.yaml$|.*\/glide\.yaml$)/ => {
+          match_filename("glide.yaml") => {
             kind: 'manifest',
             parser: :parse_glide_yaml
           },
-          /(^glide\.lock$|.*\/glide\.lock$)/ => {
+          match_filename("glide.lock") => {
             kind: 'lockfile',
             parser: :parse_glide_lockfile
           },
-          /(^Godeps\/Godeps\.json$|.*\/Godeps\/Godeps\.json$)/ => {
+          match_filename("Godeps/Godeps.json") => {
             kind: 'manifest',
             parser: :parse_godep_json
           },
-          /(^Godeps$|.*\/Godeps$)/i => {
+          match_filename("Godeps", case_insensitive: true) => {
             kind: 'manifest',
             parser: :parse_gpm
           },
-          /(^vendor\/manifest$|.*\/vendor\/manifest$)/ => {
+          match_filename("vendor/manifest") => {
             kind: 'manifest',
             parser: :parse_gb_manifest
           },
-          /(^vendor\/vendor.json$|.*\/vendor\/vendor.json$)/ => {
+          match_filename("vendor/vendor.json") => {
             kind: 'manifest',
             parser: :parse_govendor
           },
-          /(^Gopkg\.toml$|.*\/Gopkg\.toml$)/ => {
+          match_filename("Gopkg.toml") => {
             kind: 'manifest',
             parser: :parse_dep_toml
           },
-          /(^Gopkg\.lock$|.*\/Gopkg\.lock$)/ => {
+          match_filename("Gopkg.lock") => {
             kind: 'lockfile',
             parser: :parse_dep_lockfile
           },

--- a/lib/bibliothecary/parsers/hackage.rb
+++ b/lib/bibliothecary/parsers/hackage.rb
@@ -8,11 +8,11 @@ module Bibliothecary
 
       def self.mapping
         {
-          /.*\.cabal$/ => {
+          match_extension(".cabal") => {
             kind: 'manifest',
             parser: :parse_cabal
           },
-          /^cabal\.config$|.*\/cabal\.config$/ => {
+          match_extension("cabal.config") => {
             kind: 'lockfile',
             parser: :parse_cabal_config
           },

--- a/lib/bibliothecary/parsers/haxelib.rb
+++ b/lib/bibliothecary/parsers/haxelib.rb
@@ -7,7 +7,7 @@ module Bibliothecary
 
       def self.mapping
         {
-          /^haxelib\.json$|.*\/haxelib\.json$/ => {
+          match_filename("haxelib.json") => {
             kind: 'manifest',
             parser: :parse_json_runtime_manifest
           }

--- a/lib/bibliothecary/parsers/hex.rb
+++ b/lib/bibliothecary/parsers/hex.rb
@@ -7,11 +7,11 @@ module Bibliothecary
 
       def self.mapping
         {
-          /^mix\.exs$|.*\/mix\.exs$/ => {
+          match_filename("mix.exs") => {
             kind: 'manifest',
             parser: :parse_mix
           },
-          /^mix\.lock$|.*\/mix\.lock$/ => {
+          match_filename("mix.lock") => {
             kind: 'lockfile',
             parser: :parse_mix_lock
           }

--- a/lib/bibliothecary/parsers/julia.rb
+++ b/lib/bibliothecary/parsers/julia.rb
@@ -5,7 +5,7 @@ module Bibliothecary
 
       def self.mapping
         {
-          /^REQUIRE$|.*\/REQUIRE$/i => {
+          match_filename("REQUIRE", case_insensitive: true) => {
             kind: "manifest",
             parser: :parse_require
           }

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -13,24 +13,24 @@ module Bibliothecary
 
       def self.mapping
         {
-          /^ivy\.xml$|.*\/ivy\.xml$/i => {
+          match_filename("ivy.xml", case_insensitive: true) => {
             kind: 'manifest',
             parser: :parse_ivy_manifest
           },
-          /^pom\.xml$|.*\/pom\.xml$/i => {
+          match_filename("pom.xml", case_insensitive: true) => {
             kind: 'manifest',
             parser: :parse_pom_manifest
           },
-          /^build.gradle$|.*\/build.gradle$/i => {
+          match_filename("build.gradle", case_insensitive: true) => {
             kind: 'manifest',
             parser: :parse_gradle
           },
-          /^.+.xml$/i => {
+          match_extension(".xml", case_insensitive: true) => {
             content_matcher: :ivy_report?,
             kind: 'lockfile',
             parser: :parse_ivy_report
           },
-          /^gradle-dependencies-q\.txt|.*\/gradle-dependencies-q\.txt$/i => {
+          match_filename("gradle-dependencies-q.txt", case_insensitive: true) => {
             kind: 'lockfile',
             parser: :parse_gradle_resolved
           }

--- a/lib/bibliothecary/parsers/meteor.rb
+++ b/lib/bibliothecary/parsers/meteor.rb
@@ -7,7 +7,7 @@ module Bibliothecary
 
       def self.mapping
         {
-          /^versions\.json$|.*\/versions\.json$/ => {
+          match_filename("versions.json") => {
             kind: 'manifest',
             parser: :parse_json_runtime_manifest
           }

--- a/lib/bibliothecary/parsers/npm.rb
+++ b/lib/bibliothecary/parsers/npm.rb
@@ -7,19 +7,19 @@ module Bibliothecary
 
       def self.mapping
         {
-          /^package\.json$|.*\/package\.json$/ => {
+          match_filename("package.json") => {
             kind: 'manifest',
             parser: :parse_manifest
           },
-          /^npm-shrinkwrap\.json$|.*\/npm-shrinkwrap\.json$/ => {
+          match_filename("npm-shrinkwrap.json") => {
             kind: 'lockfile',
             parser: :parse_shrinkwrap
           },
-          /^yarn\.lock$|.*\/yarn.lock$/ => {
+          match_filename("yarn.lock") => {
             kind: 'lockfile',
             parser: :parse_yarn_lock
           },
-          /^package-lock\.json$|.*\/package-lock\.json$/ => {
+          match_filename("package-lock.json") => {
             kind: 'lockfile',
             parser: :parse_package_lock
           }

--- a/lib/bibliothecary/parsers/nuget.rb
+++ b/lib/bibliothecary/parsers/nuget.rb
@@ -8,27 +8,27 @@ module Bibliothecary
 
       def self.mapping
         {
-          /(^Project\.json$|.*\/Project\.json$)/ => {
+          match_filename("Project.json") => {
             kind: 'manifest',
             parser: :parse_json_runtime_manifest
           },
-          /(^Project\.lock\.json$|.*\/Project\.lock\.json$)/ => {
+          match_filename("Project.lock.json") => {
             kind: 'lockfile',
             parser: :parse_project_lock_json
           },
-          /(^packages\.config$|.*\/packages\.config$)/ => {
+          match_filename("packages.config") => {
             kind: 'manifest',
             parser: :parse_packages_config
           },
-          /(^[A-Za-z0-9_-]+\.nuspec$|.*\/[A-Za-z0-9_-]+\.nuspec$)/ => {
+          match_extension(".nuspec") => {
             kind: 'manifest',
             parser: :parse_nuspec
           },
-          /(^[A-Za-z0-9_-]+\.csproj$|.*\/[A-Za-z0-9_-]+\.csproj$)/ => {
+          match_extension(".csproj") => {
             kind: 'manifest',
             parser: :parse_csproj
           },
-          /(^paket\.lock$|.*\/paket\.lock$)/ => {
+          match_filename("paket.lock") => {
             kind: 'lockfile',
             parser: :parse_paket_lock
           }

--- a/lib/bibliothecary/parsers/packagist.rb
+++ b/lib/bibliothecary/parsers/packagist.rb
@@ -7,11 +7,11 @@ module Bibliothecary
 
       def self.mapping
         {
-          /^composer\.json$|.*\/composer\.json$/ => {
+          match_filename("composer.json") => {
             kind: 'manifest',
             parser: :parse_manifest
           },
-          /^composer\.lock$|.*\/composer\.lock$/ => {
+          match_filename("composer.lock") => {
             kind: 'lockfile',
             parser: :parse_lockfile
           }

--- a/lib/bibliothecary/parsers/pub.rb
+++ b/lib/bibliothecary/parsers/pub.rb
@@ -7,11 +7,11 @@ module Bibliothecary
 
       def self.mapping
         {
-          /^pubspec\.yaml$|.*\/pubspec\.yaml$/i => {
+          match_filename("pubspec.yaml", case_insensitive: true) => {
             kind: 'manifest',
             parser: :parse_yaml_manifest
           },
-          /^pubspec\.lock$|.*\/pubspec\.lock$/i => {
+          match_filename("pubspec.lock", case_insensitive: true) => {
             kind: 'lockfile',
             parser: :parse_yaml_lockfile
           }

--- a/lib/bibliothecary/parsers/pypi.rb
+++ b/lib/bibliothecary/parsers/pypi.rb
@@ -6,24 +6,25 @@ module Bibliothecary
       INSTALL_REGEXP = /install_requires\s*=\s*\[([\s\S]*?)\]/
       REQUIRE_REGEXP = /([a-zA-Z0-9]+[a-zA-Z0-9\-_\.]+)([><=\w\.,]+)?/
       REQUIREMENTS_REGEXP = /^#{REQUIRE_REGEXP}/
+      MANIFEST_REGEXP = /.*require[^\/]*(\/)?[^\/]*\.(txt|pip)$/
 
       def self.mapping
         {
-          /.*require[^\/]*(\/)?[^\/]*\.(txt|pip)$/ => {
+          lambda { |p| MANIFEST_REGEXP.match(p) } => {
             kind: 'manifest',
             parser: :parse_requirements_txt,
             can_have_lockfile: false
           },
-          /^setup\.py$|.*\/setup.py$/ => {
+          match_filename("setup.py") => {
             kind: 'manifest',
             parser: :parse_setup_py,
             can_have_lockfile: false
           },
-          /^Pipfile$|.*\/Pipfile$/ => {
+          match_filename("Pipfile") => {
             kind: 'manifest',
             parser: :parse_pipfile
           },
-          /^Pipfile\.lock$|.*\/Pipfile\.lock$/ => {
+          match_filename("Pipfile.lock") => {
             kind: 'lockfile',
             parser: :parse_pipfile_lock
           }

--- a/lib/bibliothecary/parsers/rubygems.rb
+++ b/lib/bibliothecary/parsers/rubygems.rb
@@ -10,16 +10,16 @@ module Bibliothecary
 
       def self.mapping
         {
-          /^Gemfile$|^gems\.rb$|.*\/Gemfile$|.*\/gems\.rb$/ => {
+          match_filenames("Gemfile", "gems.rb") => {
             kind: 'manifest',
             parser: :parse_gemfile
           },
-          /^[A-Za-z0-9_-]+\.gemspec$|.*\/[A-Za-z0-9_-]+\.gemspec$/ => {
+          match_extension(".gemspec") => {
             kind: 'manifest',
             parser: :parse_gemspec,
             can_have_lockfile: false
           },
-          /^Gemfile\.lock$|^gems\.locked$|.*\/gems\.locked$|.*\/Gemfile\.lock$/ => {
+          match_filenames("Gemfile.lock", "gems.locked") => {
             kind: 'lockfile',
             parser: :parse_gemfile_lock
           }

--- a/lib/bibliothecary/parsers/shard.rb
+++ b/lib/bibliothecary/parsers/shard.rb
@@ -7,11 +7,11 @@ module Bibliothecary
 
       def self.mapping
         {
-          /^shard\.yml$|.*\/shard\.yml$/i => {
+          match_filename("shard.yml", case_insensitive: true) => {
             kind: 'manifest',
             parser: :parse_yaml_manifest
           },
-          /^shard\.lock$|.*\/shard\.lock$/i => {
+          match_filename("shard.lock", case_insensitive: true) => {
             kind: 'lockfile',
             parser: :parse_yaml_lockfile
           }

--- a/lib/bibliothecary/parsers/swift_pm.rb
+++ b/lib/bibliothecary/parsers/swift_pm.rb
@@ -5,7 +5,7 @@ module Bibliothecary
 
       def self.mapping
         {
-          /^Package\.swift$|.*\/Package\.swift$/i => {
+          match_filename("Package.swift", case_insensitive: true) => {
             kind: 'manifest',
             parser: :parse_package_swift
           }

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "6.3.2"
+  VERSION = "6.4.0"
 end


### PR DESCRIPTION
I'm able to get around a 5x speedup by ditching regexes for matching paths.

I've left the original regexes in place for comparison, I'll remove them before this merges.

The first commit fixes a spec that's failing on master (at least for me locally)