### PR TITLE
Add support for <dependencyManagement> namespace in pom.xml

### DIFF
--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -111,18 +111,17 @@ module Bibliothecary
 
       def self.parse_pom_manifest(file_contents)
         manifest = Ox.parse file_contents
-        if manifest.respond_to?('project')
-          xml = manifest.project
-        else
-          xml = manifest
-        end
-        return [] unless xml.respond_to?('dependencies')
-        xml.dependencies.locate('dependency').map do |dependency|
-          {
-            name: "#{extract_pom_dep_info(xml, dependency, 'groupId')}:#{extract_pom_dep_info(xml, dependency, 'artifactId')}",
-            requirement: extract_pom_dep_info(xml, dependency, 'version'),
-            type: extract_pom_dep_info(xml, dependency, 'scope') || 'runtime'
-          }
+        xml = manifest.respond_to?('project') ? manifest.project : manifest
+        [].tap do |deps|
+          ['dependencies/dependency', 'dependencyManagement/dependencies/dependency'].each do |deps_xpath|
+            xml.locate(deps_xpath).each do |dep|
+              deps.push({
+                name: "#{extract_pom_dep_info(xml, dep, 'groupId')}:#{extract_pom_dep_info(xml, dep, 'artifactId')}",
+                requirement: extract_pom_dep_info(xml, dep, 'version'),
+                type: extract_pom_dep_info(xml, dep, 'scope') || 'runtime'
+              })
+            end
+          end
         end
       end
 

--- a/spec/fixtures/pom.xml
+++ b/spec/fixtures/pom.xml
@@ -66,6 +66,23 @@
         </developer>
     </developers>
 
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.ant</groupId>
+                <artifactId>ant</artifactId>
+                <version>1.9.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>commons-lang</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>2.6</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!--JERSEY SERVLET-->
         <dependency>

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -79,7 +79,10 @@ describe Bibliothecary::Parsers::Maven do
         :type=>"runtime"},
         {:name=>"com.typesafe:config", :requirement=>"1.2.1", :type=>"runtime"},
         {:name=>"org.testng:testng", :requirement=>"6.8.7", :type=>"test"},
-        {:name=>"org.mockito:mockito-all", :requirement=>"1.8.4", :type=>"test"}
+        {:name=>"org.mockito:mockito-all", :requirement=>"1.8.4", :type=>"test"},
+        # From dependencyManagement section
+        {:name=>"org.apache.ant:ant", :requirement=>"1.9.2", :type=>"runtime"},
+        {:name=>"commons-lang:commons-lang",:requirement=>"2.6", :type=>"runtime"}
       ],
       kind: 'manifest',
       success: true


### PR DESCRIPTION
This adds support for the `<dependencyManagement>` namespace tag in pom.xml, which can be used to define a parent pom.xml's deps/versions. Children then define these without a version, and inherit the versions from the parents.

Maven docs [here](https://maven.apache.org/pom.html#Dependency_Management). Addresses https://github.com/librariesio/bibliothecary/issues/74 .