### PR TITLE
Adding parser support for Go Modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ All available config options are in: https://github.com/librariesio/bibliothecar
   - vendor/vendor.json
   - Gopkg.toml
   - Gopkg.lock
+  - go.mod
+  - go.sum
 - Elm
   - elm-package.json
   - elm_dependencies.json

--- a/lib/bibliothecary/parsers/go.rb
+++ b/lib/bibliothecary/parsers/go.rb
@@ -124,14 +124,13 @@ module Bibliothecary
       def self.parse_go_sum(file_contents)
         deps = []
         file_contents.lines.map(&:strip).each do |line|
-          match = line.match(GOSUM_REGEX)
-
-          next unless match
-          deps << {
-            name: match[1].strip,
-            requirement: match[2].strip.split('/').first || '*',
-            type: 'runtime'
-          }
+          if match = line.match(GOSUM_REGEX)
+            deps << {
+              name: match[1].strip,
+              requirement: match[2].strip.split('/').first || '*',
+              type: 'runtime'
+            }
+          end
         end
         deps.uniq
       end

--- a/spec/fixtures/go.mod
+++ b/spec/fixtures/go.mod
@@ -1,0 +1,6 @@
+module github.com/libraries/bibliothecary
+
+require (
+  # No versions
+  github.com/logrusorgru/aurora v0.0.0-20190428105938-cea283e61946
+)

--- a/spec/fixtures/go.mod
+++ b/spec/fixtures/go.mod
@@ -1,5 +1,7 @@
 module mod
 
+go 1.12
+
 require (
   github.com/go-check/check v0.0.0-20180628173108-788fd7840127 // indirect
   github.com/gomodule/redigo v2.0.0+incompatible // indirect

--- a/spec/fixtures/go.mod
+++ b/spec/fixtures/go.mod
@@ -7,4 +7,5 @@ require (
   github.com/gomodule/redigo v2.0.0+incompatible // indirect
   github.com/kr/pretty v0.1.0 // indirect
   github.com/replicon/fast-archiver v0.0.0-20121220195659-060bf9adec25 // indirect
+  gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0
 )

--- a/spec/fixtures/go.mod
+++ b/spec/fixtures/go.mod
@@ -1,6 +1,8 @@
-module github.com/libraries/bibliothecary
+module mod
 
 require (
-  # No versions
-  github.com/logrusorgru/aurora v0.0.0-20190428105938-cea283e61946
+  github.com/go-check/check v0.0.0-20180628173108-788fd7840127 // indirect
+  github.com/gomodule/redigo v2.0.0+incompatible // indirect
+  github.com/kr/pretty v0.1.0 // indirect
+  github.com/replicon/fast-archiver v0.0.0-20121220195659-060bf9adec25 // indirect
 )

--- a/spec/fixtures/go.sum
+++ b/spec/fixtures/go.sum
@@ -1,0 +1,2 @@
+github.com/logrusorgru/aurora v0.0.0-20190428105938-cea283e61946 h1:z+WaKrgu3kCpcdnbK9YG+JThpOCd1nU5jO5ToVmSlR4=
+github.com/logrusorgru/aurora v0.0.0-20190428105938-cea283e61946/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=

--- a/spec/fixtures/go.sum
+++ b/spec/fixtures/go.sum
@@ -1,2 +1,11 @@
-github.com/logrusorgru/aurora v0.0.0-20190428105938-cea283e61946 h1:z+WaKrgu3kCpcdnbK9YG+JThpOCd1nU5jO5ToVmSlR4=
-github.com/logrusorgru/aurora v0.0.0-20190428105938-cea283e61946/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
+github.com/go-check/check v0.0.0-20180628173108-788fd7840127 h1:0gkP6mzaMqkmpcJYCFOLkIBwI7xFExG03bbkOkCvUPI=
+github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
+github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=
+github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/replicon/fast-archiver v0.0.0-20121220195659-060bf9adec25 h1:aq3XSz9htmdvrxpK6eBIbjs3SaN8G1D9RuKkDo4PRnw=
+github.com/replicon/fast-archiver v0.0.0-20121220195659-060bf9adec25/go.mod h1:R9DTtFe2IYmHTz+jzYtQmqqltTKfdZCqx4NgPIEg6oY=

--- a/spec/fixtures/go.sum
+++ b/spec/fixtures/go.sum
@@ -9,3 +9,5 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/replicon/fast-archiver v0.0.0-20121220195659-060bf9adec25 h1:aq3XSz9htmdvrxpK6eBIbjs3SaN8G1D9RuKkDo4PRnw=
 github.com/replicon/fast-archiver v0.0.0-20121220195659-060bf9adec25/go.mod h1:R9DTtFe2IYmHTz+jzYtQmqqltTKfdZCqx4NgPIEg6oY=
+gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0 h1:POO/ycCATvegFmVuPpQzZFJ+pGZeX22Ufu6fibxDVjU=
+gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=

--- a/spec/parsers/go_spec.rb
+++ b/spec/parsers/go_spec.rb
@@ -27,7 +27,7 @@ describe Bibliothecary::Parsers::Go do
 
         {:name=>"logrusorgru/aurora", :requirement=>"v0.0.0-20190428105938-cea283e61946", :type=>"runtime"}
       ],
-      kind: 'lockfile',
+      kind: 'checksum',
       success: true
     })
   end

--- a/spec/parsers/go_spec.rb
+++ b/spec/parsers/go_spec.rb
@@ -5,6 +5,33 @@ describe Bibliothecary::Parsers::Go do
     expect(described_class.platform_name).to eq('go')
   end
 
+  it 'parses depenencies from go.mod' do
+    expect(described_class.analyse_contents('go.mod', load_fixture('go.mod'))).to eq({
+      :platform=>"go",
+      :path=>"go.mod",
+      :dependencies=>[
+        {:name=>"logrusorgru/aurora", :requirement=>"v0.0.0-20190428105938-cea283e61946", :type=>"runtime"}
+      ],
+      kind: 'manifest',
+      success: true
+    })
+  end
+
+  it 'parses depenencies from go.sum' do
+    expect(described_class.analyse_contents('go.sum', load_fixture('go.sum'))).to eq({
+      :platform=>"go",
+      :path=>"go.sum",
+      :dependencies=>[
+        # github.com/logrusorgru/aurora v0.0.0-20190428105938-cea283e61946 h1:z+WaKrgu3kCpcdnbK9YG+JThpOCd1nU5jO5ToVmSlR4=
+        # github.com/logrusorgru/aurora v0.0.0-20190428105938-cea283e61946/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
+
+        {:name=>"logrusorgru/aurora", :requirement=>"v0.0.0-20190428105938-cea283e61946", :type=>"runtime"}
+      ],
+      kind: 'lockfile',
+      success: true
+    })
+  end
+
   it 'parses dependencies from glide.yaml' do
     expect(described_class.analyse_contents('glide.yaml', load_fixture('glide.yaml'))).to eq({
       :platform=>"go",

--- a/spec/parsers/go_spec.rb
+++ b/spec/parsers/go_spec.rb
@@ -21,6 +21,9 @@ describe Bibliothecary::Parsers::Go do
          :type=>"runtime"},
         {:name=>"github.com/replicon/fast-archiver",
          :requirement=>"v0.0.0-20121220195659-060bf9adec25",
+         :type=>"runtime"},
+        {:name=>"gopkg.in/yaml.v1",
+         :requirement=>"v1.0.0-20140924161607-9f9df34309c0",
          :type=>"runtime"}
       ],
       kind: 'manifest',
@@ -50,8 +53,11 @@ describe Bibliothecary::Parsers::Go do
          :type=>"runtime"},
         {:name=>"github.com/replicon/fast-archiver",
          :requirement=>"v0.0.0-20121220195659-060bf9adec25",
-         :type=>"runtime"}
-      ],
+         :type=>"runtime"},
+        {:name=>"gopkg.in/yaml.v1",
+         :requirement=>"v1.0.0-20140924161607-9f9df34309c0",
+         :type=>"runtime"},
+        ],
       kind: 'lockfile',
       success: true
     })

--- a/spec/parsers/go_spec.rb
+++ b/spec/parsers/go_spec.rb
@@ -15,10 +15,10 @@ describe Bibliothecary::Parsers::Go do
          :type=>"runtime"},
         {:name=>"github.com/gomodule/redigo",
          :requirement=>"v2.0.0+incompatible",
-         :type=>"runtime"}
+         :type=>"runtime"},
         {:name=>"github.com/kr/pretty",
          :requirement=>"v0.1.0",
-         :type=>"runtime"}
+         :type=>"runtime"},
         {:name=>"github.com/replicon/fast-archiver",
          :requirement=>"v0.0.0-20121220195659-060bf9adec25",
          :type=>"runtime"}
@@ -43,7 +43,7 @@ describe Bibliothecary::Parsers::Go do
          :requirement=>"v0.1.0",
          :type=>"runtime"},
         {:name=>"github.com/kr/pty",
-         :requirement=>"v0.1.0",
+         :requirement=>"v1.1.1",
          :type=>"runtime"},
         {:name=>"github.com/kr/text",
          :requirement=>"v0.1.0",

--- a/spec/parsers/go_spec.rb
+++ b/spec/parsers/go_spec.rb
@@ -10,7 +10,18 @@ describe Bibliothecary::Parsers::Go do
       :platform=>"go",
       :path=>"go.mod",
       :dependencies=>[
-        {:name=>"logrusorgru/aurora", :requirement=>"v0.0.0-20190428105938-cea283e61946", :type=>"runtime"}
+        {:name=>"github.com/go-check/check",
+         :requirement=>"v0.0.0-20180628173108-788fd7840127",
+         :type=>"runtime"},
+        {:name=>"github.com/gomodule/redigo",
+         :requirement=>"v2.0.0+incompatible",
+         :type=>"runtime"}
+        {:name=>"github.com/kr/pretty",
+         :requirement=>"v0.1.0",
+         :type=>"runtime"}
+        {:name=>"github.com/replicon/fast-archiver",
+         :requirement=>"v0.0.0-20121220195659-060bf9adec25",
+         :type=>"runtime"}
       ],
       kind: 'manifest',
       success: true
@@ -22,10 +33,24 @@ describe Bibliothecary::Parsers::Go do
       :platform=>"go",
       :path=>"go.sum",
       :dependencies=>[
-        # github.com/logrusorgru/aurora v0.0.0-20190428105938-cea283e61946 h1:z+WaKrgu3kCpcdnbK9YG+JThpOCd1nU5jO5ToVmSlR4=
-        # github.com/logrusorgru/aurora v0.0.0-20190428105938-cea283e61946/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
-
-        {:name=>"logrusorgru/aurora", :requirement=>"v0.0.0-20190428105938-cea283e61946", :type=>"runtime"}
+        {:name=>"github.com/go-check/check",
+         :requirement=>"v0.0.0-20180628173108-788fd7840127",
+         :type=>"runtime"},
+        {:name=>"github.com/gomodule/redigo",
+         :requirement=>"v2.0.0+incompatible",
+         :type=>"runtime"},
+        {:name=>"github.com/kr/pretty",
+         :requirement=>"v0.1.0",
+         :type=>"runtime"},
+        {:name=>"github.com/kr/pty",
+         :requirement=>"v0.1.0",
+         :type=>"runtime"},
+        {:name=>"github.com/kr/text",
+         :requirement=>"v0.1.0",
+         :type=>"runtime"},
+        {:name=>"github.com/replicon/fast-archiver",
+         :requirement=>"v0.0.0-20121220195659-060bf9adec25",
+         :type=>"runtime"}
       ],
       kind: 'checksum',
       success: true
@@ -218,6 +243,8 @@ describe Bibliothecary::Parsers::Go do
   end
 
   it 'matches valid manifest filepaths' do
+    expect(described_class.match?('go.mod')).to be_truthy
+    expect(described_class.match?('go.sum')).to be_truthy
     expect(described_class.match?('Godeps/Godeps.json')).to be_truthy
     expect(described_class.match?('vendor/manifest')).to be_truthy
     expect(described_class.match?('glide.yaml')).to be_truthy

--- a/spec/parsers/go_spec.rb
+++ b/spec/parsers/go_spec.rb
@@ -52,7 +52,7 @@ describe Bibliothecary::Parsers::Go do
          :requirement=>"v0.0.0-20121220195659-060bf9adec25",
          :type=>"runtime"}
       ],
-      kind: 'checksum',
+      kind: 'lockfile',
       success: true
     })
   end


### PR DESCRIPTION
Kicking this off. 

### Docs

* [Go Modules wiki](https://github.com/golang/go/wiki/Modules)
* [Go Modules proposal](https://go.googlesource.com/proposal/+/master/design/24301-versioned-go.md)
* [good intro to Go Modules](https://roberto.selbach.ca/intro-to-go-modules/)

### Example Go Modules package

* [go-yaml/yaml on GH](https://github.com/go-yaml/yaml)
* [go-yaml/yaml on go-search](https://go-search.org/view?id=gopkg.in%2fyaml.v2)
* [go-yaml/yaml on Libraries, notably missing deps](https://libraries.io/go/github.com%2Fgo-yaml%2Fyaml)

### Open Questions

* [x] should we maintain the full [pseudo-version](https://golang.org/cmd/go/#hdr-Pseudo_versions) for packages that don't have semver?
* [x] good non-GH examples?
* [x] I've marked `go.sum` as a `checksum` file because the docs [explicitly say it isn't a lock file](https://github.com/golang/go/wiki/Modules#is-gosum-a-lock-file-why-does-gosum-include-information-for-module-versions-i-am-no-longer-using). But it does break down indirect deps and can have more than `go.sum`, so maybe we **should** consider it a `lockfile`?
* [x] these regexps feel a bit janky? But Go Modules notably chose a non-standard depfile syntax (see [this discussion](https://github.com/golang/go/issues/23966))