### PR TITLE
Rubygems parser Gemfile.lock chomp nonprinting newline chars

### DIFF
--- a/lib/bibliothecary/parsers/rubygems.rb
+++ b/lib/bibliothecary/parsers/rubygems.rb
@@ -29,7 +29,8 @@ module Bibliothecary
       end
 
       def self.parse_gemfile_lock(manifest)
-        manifest.split("\n").map do |line|
+        manifest.each_line.map do |line|
+          line.chomp!
           match = line.match(NAME_VERSION_4)
           next unless match
           name = match[1]

--- a/lib/bibliothecary/parsers/rubygems.rb
+++ b/lib/bibliothecary/parsers/rubygems.rb
@@ -29,8 +29,7 @@ module Bibliothecary
       end
 
       def self.parse_gemfile_lock(manifest)
-        manifest.each_line.map do |line|
-          line.chomp!
+        manifest.lines(chomp: true).map do |line|
           match = line.match(NAME_VERSION_4)
           next unless match
           name = match[1]

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "6.7.0"
+  VERSION = "6.7.1"
 end

--- a/spec/fixtures/GemfileLineEndings.lock
+++ b/spec/fixtures/GemfileLineEndings.lock
@@ -1,0 +1,4 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rails (5.2.3)

--- a/spec/parsers/rubygems_spec.rb
+++ b/spec/parsers/rubygems_spec.rb
@@ -76,10 +76,15 @@ describe Bibliothecary::Parsers::Rubygems do
   end
 
   it 'parses dependencies from Gemfile.lock with windows line endings' do
+    fixture = load_fixture("GemfileLineEndings.lock")
+    # If this fails, the line endings changed, on this file.
+    # to fix it, run `vim spec/fixtures/GemfileLineEndings.lock +"set ff=dos" +wq`
+    expect(fixture).to include("\r\n")
+
     expect(
       described_class.analyse_contents(
         "Gemfile.lock",
-        "GEM\r\n  remote: https://rubygems.org/\r\n  specs:\r\n    rails (5.2.3)\r\n")).to eq({
+        fixture)).to eq({
           :platform=>"rubygems",
           :path=>"Gemfile.lock",
           :dependencies=>[

--- a/spec/parsers/rubygems_spec.rb
+++ b/spec/parsers/rubygems_spec.rb
@@ -75,6 +75,21 @@ describe Bibliothecary::Parsers::Rubygems do
     })
   end
 
+  it 'parses dependencies from Gemfile.lock with windows line endings' do
+    expect(
+      described_class.analyse_contents(
+        "Gemfile.lock",
+        "GEM\r\n  remote: https://rubygems.org/\r\n  specs:\r\n    rails (5.2.3)\r\n")).to eq({
+          :platform=>"rubygems",
+          :path=>"Gemfile.lock",
+          :dependencies=>[
+            {:name=>"rails", :requirement=>"5.2.3", :type=>"runtime"},
+          ],
+          kind: 'lockfile',
+          success: true
+        })
+  end
+
   it 'matches valid manifest filepaths' do
     expect(described_class.match?('devise.gemspec')).to be_truthy
     expect(described_class.match?('Gemfile')).to be_truthy

--- a/spec/parsers/rubygems_spec.rb
+++ b/spec/parsers/rubygems_spec.rb
@@ -82,17 +82,15 @@ describe Bibliothecary::Parsers::Rubygems do
     expect(fixture).to include("\r\n")
 
     expect(
-      described_class.analyse_contents(
-        "Gemfile.lock",
-        fixture)).to eq({
-          :platform=>"rubygems",
-          :path=>"Gemfile.lock",
-          :dependencies=>[
-            {:name=>"rails", :requirement=>"5.2.3", :type=>"runtime"},
-          ],
-          kind: 'lockfile',
-          success: true
-        })
+      described_class.analyse_contents("Gemfile.lock", fixture)).to eq({
+        :platform=>"rubygems",
+        :path=>"Gemfile.lock",
+        :dependencies=>[
+          {:name=>"rails", :requirement=>"5.2.3", :type=>"runtime"},
+        ],
+        kind: 'lockfile',
+        success: true
+      })
   end
 
   it 'matches valid manifest filepaths' do


### PR DESCRIPTION
We tried scanning a file that appears to have been made on windows. This caused there to be an error message of: `Gemfile.lock: undefined method 'gsub' for nil:NilClass"` because the match didn't match ` name (ver)\r`

Deciding to chomp away the newline characters