### PR TITLE
Adds Bibliothecary.configuration.ignored_deps option

### DIFF
--- a/lib/bibliothecary.rb
+++ b/lib/bibliothecary.rb
@@ -53,6 +53,10 @@ module Bibliothecary
     configuration.ignored_files
   end
 
+  def self.ignored_deps
+    configuration.ignored_deps
+  end
+
   class << self
     attr_writer :configuration
   end

--- a/lib/bibliothecary/analyser.rb
+++ b/lib/bibliothecary/analyser.rb
@@ -119,10 +119,18 @@ module Bibliothecary
       def analyse_contents_from_info(info)
         kind = determine_kind_from_info(info)
         dependencies = parse_file(info.relative_path, info.contents)
+        dependencies = remove_ignored_deps(File.basename(info.relative_path), dependencies)
 
         Bibliothecary::Analyser::create_analysis(platform_name, info.relative_path, kind, dependencies || [])
       rescue Bibliothecary::FileParsingError => e
         Bibliothecary::Analyser::create_error_analysis(platform_name, info.relative_path, kind, e.message)
+      end
+
+      def remove_ignored_deps(filename, dependencies)
+        dependencies.reject { |dep|
+          Bibliothecary.configuration.ignored_deps.key?(filename) &&
+            Bibliothecary.configuration.ignored_deps[filename].any? { |re| dep[:name] =~ re }
+        }
       end
 
       # calling this with contents=nil can produce less-informed

--- a/lib/bibliothecary/configuration.rb
+++ b/lib/bibliothecary/configuration.rb
@@ -14,7 +14,7 @@ module Bibliothecary
     def initialize
       @ignored_dirs = ['.git', 'node_modules', 'bower_components', 'vendor', 'dist']
       @ignored_files = []
-      @ignored_deps = {} # e.g. { 'packagist' => [/a_regexp/] }
+      @ignored_deps = {} # e.g. { 'composer.json' => [/some_depname_regexp/, /another_depname_regexp/] }
       @carthage_parser_host = 'https://carthage.libraries.io'
       @clojars_parser_host  = 'https://clojars.libraries.io'
       @mix_parser_host      = 'https://mix.libraries.io'

--- a/lib/bibliothecary/configuration.rb
+++ b/lib/bibliothecary/configuration.rb
@@ -2,6 +2,7 @@ module Bibliothecary
   class Configuration
     attr_accessor :ignored_dirs
     attr_accessor :ignored_files
+    attr_accessor :ignored_deps
     attr_accessor :carthage_parser_host
     attr_accessor :clojars_parser_host
     attr_accessor :mix_parser_host
@@ -13,6 +14,7 @@ module Bibliothecary
     def initialize
       @ignored_dirs = ['.git', 'node_modules', 'bower_components', 'vendor', 'dist']
       @ignored_files = []
+      @ignored_deps = {} # e.g. { 'packagist' => [/a_regexp/] }
       @carthage_parser_host = 'https://carthage.libraries.io'
       @clojars_parser_host  = 'https://clojars.libraries.io'
       @mix_parser_host      = 'https://mix.libraries.io'

--- a/spec/bibliothecary_spec.rb
+++ b/spec/bibliothecary_spec.rb
@@ -282,20 +282,16 @@ describe Bibliothecary do
     Bibliothecary.configure do |config|
       config.ignored_dirs = ['foobar']
       config.ignored_files = ['hello']
+      config.ignored_deps = {
+        "composer.json" => [/^php$/i]
+      }
     end
 
     expect(Bibliothecary.ignored_dirs).to eq(['foobar'])
     expect(Bibliothecary.ignored_files).to eq(['hello'])
+    expect(Bibliothecary.ignored_deps).to eq({"composer.json" => [/^php$/i]})
 
     Bibliothecary.reset
-  end
-
-  it 'allows customization of config options' do
-    Bibliothecary.configure do |config|
-      config.ignored_dirs = ['foobar']
-    end
-
-    expect(Bibliothecary.ignored_dirs).to eq(['foobar'])
   end
 
   it 'allows resetting of config options' do

--- a/spec/bibliothecary_spec.rb
+++ b/spec/bibliothecary_spec.rb
@@ -58,6 +58,29 @@ describe Bibliothecary do
     }])
   end
 
+  it 'analyses contents of a file while ignoring ignored_deps' do
+    Bibliothecary.configure do |config|
+      config.ignored_deps = {
+        "composer.json" => [/^php$/i, /^ext-.+$/i],
+        "composer.lock" => [/^php$/i, /^ext-.+$/i],
+      }
+    end
+
+    expect(described_class.analyse_file('composer.json', load_fixture('composer.json'))).to eq([{
+      :platform=>"packagist",
+      :path=>"composer.json",
+      :dependencies=>[
+        {:name=>"laravel/framework", :requirement=>"5.0.*", :type=>"runtime"},
+        {:name=>"phpunit/phpunit", :requirement=>"~4.0", :type=>"development"},
+        {:name=>"phpspec/phpspec", :requirement=>"~2.1", :type=>"development"}
+      ],
+      :kind => 'manifest',
+      success: true
+    }])
+
+    Bibliothecary.reset
+  end
+
   it 'searches a folder for manifests and parses them' do
     Bibliothecary.configure do |config|
       config.ignored_dirs.push("spec/fixtures")

--- a/spec/fixtures/composer.json
+++ b/spec/fixtures/composer.json
@@ -5,7 +5,9 @@
 	"license": "MIT",
 	"type": "project",
 	"require": {
-		"laravel/framework": "5.0.*"
+		"laravel/framework": "5.0.*",
+		"php": "^7.1",
+		"ext-mbstring": "*"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.0",

--- a/spec/parsers/packagist_spec.rb
+++ b/spec/parsers/packagist_spec.rb
@@ -11,8 +11,10 @@ describe Bibliothecary::Parsers::Packagist do
       :path=>"composer.json",
       :dependencies=>[
         {:name=>"laravel/framework", :requirement=>"5.0.*", :type=>"runtime"},
+        {:name=>"php", :requirement=>"^7.1", :type=>"runtime"},
+        {:name=>"ext-mbstring", :requirement=>"*", :type=>"runtime"},
         {:name=>"phpunit/phpunit", :requirement=>"~4.0", :type=>"development"},
-        {:name=>"phpspec/phpspec", :requirement=>"~2.1", :type=>"development"}
+        {:name=>"phpspec/phpspec", :requirement=>"~2.1", :type=>"development"},
       ],
       kind: 'manifest',
       success: true


### PR DESCRIPTION
### Usage

``` ruby
    Bibliothecary.configure do |config|
      config.ignored_deps = {
        "composer.json" => [/^php$/i]
      }
    end
```

This will omit any dependencies from `"composer.json"` files that matches the regexes specified.

### Why?

You may want to skip certain dependencies from an analysis. For example, Composer [allows you](https://getcomposer.org/doc/04-schema.md#package-links) to specify the version of PHP or the required system extensions for PHP alongside your regular deps:

``` json
"require": {
		"laravel/framework": "5.0.*"
		"laravel/framework": "5.0.*",
		"php": "^7.1",
		"ext-mbstring": "*"
	},
```

But `php` (the language) and `ext-mbstring` (a system extension) aren't really packages, so this option lets you skip them when parsing a manifest. 