### PR TITLE
Allow Additional Properties to be Added to maven parse_pom_manifest

### DIFF
--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -151,7 +151,7 @@ module Bibliothecary
         value = field.nodes.first
         match = value.match(/^\$\{(.+)\}/)
         if match
-          return value unless xml.respond_to? 'properties' || !parent_properties.empty?
+          return value if !xml.respond_to?('properties') && parent_properties.empty?
           prop_field = xml.properties.locate(match[1]).first
           parent_prop = parent_properties[match[1]]
           if prop_field

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "6.7.1"
+  VERSION = "6.7.2"
 end

--- a/spec/fixtures/pom.xml
+++ b/spec/fixtures/pom.xml
@@ -84,6 +84,11 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>echo-parent</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <!--JERSEY SERVLET-->
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>

--- a/spec/fixtures/pom.xml
+++ b/spec/fixtures/pom.xml
@@ -261,6 +261,12 @@
             <version>1.8.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.libraries</groupId>
+            <artifactId>bibliothecary</artifactId>
+            <version>${bibliothecary.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -11,6 +11,9 @@ describe Bibliothecary::Parsers::Maven do
       :platform=>"maven",
       :path=>"pom.xml",
       :dependencies=>[
+        {:name=>"org.accidia:echo-parent",
+        :requirement=>"0.1.23",
+        :type=>"runtime"},
         {:name=>"org.glassfish.jersey.core:jersey-server",
         :requirement=>"2.16",
         :type=>"runtime"},

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'pry'
 
 describe Bibliothecary::Parsers::Maven do
   it 'has a platform name' do
@@ -80,9 +81,10 @@ describe Bibliothecary::Parsers::Maven do
         {:name=>"com.typesafe:config", :requirement=>"1.2.1", :type=>"runtime"},
         {:name=>"org.testng:testng", :requirement=>"6.8.7", :type=>"test"},
         {:name=>"org.mockito:mockito-all", :requirement=>"1.8.4", :type=>"test"},
+        {:name=>"io.libraries:bibliothecary", :requirement=>"${bibliothecary.version}", :type=>"test"},
         # From dependencyManagement section
         {:name=>"org.apache.ant:ant", :requirement=>"1.9.2", :type=>"runtime"},
-        {:name=>"commons-lang:commons-lang",:requirement=>"2.6", :type=>"runtime"}
+        {:name=>"commons-lang:commons-lang",:requirement=>"2.6", :type=>"runtime"},
       ],
       kind: 'manifest',
       success: true
@@ -300,5 +302,14 @@ describe Bibliothecary::Parsers::Maven do
 
     expect(test_compile_classpath.length).to eq 187
     expect(test_runtime_classpath.select {|item| item[:name] == "org.slf4j:jul-to-slf4j"}.length).to eq 1
+  end
+
+  it 'uses parent properties during resolve' do
+    parent_props = {"bibliothecary.version"=>"9.9.9"}
+    deps = described_class.parse_pom_manifest(load_fixture('pom.xml'), parent_props)
+    jersey_dep = deps.find do |dep| 
+      dep[:name] == "io.libraries:bibliothecary" 
+    end
+    expect(jersey_dep[:requirement]).to eq "9.9.9"
   end
 end

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'pry'
 
 describe Bibliothecary::Parsers::Maven do
   it 'has a platform name' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,3 +27,5 @@ VCR.configure do |c|
   c.configure_rspec_metadata!
   c.hook_into :webmock
 end
+
+require 'pry'


### PR DESCRIPTION
The idea is that properties from parent pom files can be passed in and be used to resolve dependency values.