### PR TITLE
First pass on making Conda support Pip manifest

### DIFF
--- a/lib/bibliothecary/parsers/conda.rb
+++ b/lib/bibliothecary/parsers/conda.rb
@@ -41,7 +41,7 @@ module Bibliothecary
       private
 
       def self.parse_pip(info)
-        dependencies = YAML.load(info.contents).dig("dependencies")
+        dependencies = YAML.load(info.contents)["dependencies"]
         pip = dependencies.find { |dep| dep.is_a?(Hash) && dep.dig("pip")}
         return nil unless pip
 

--- a/lib/bibliothecary/parsers/conda.rb
+++ b/lib/bibliothecary/parsers/conda.rb
@@ -49,7 +49,7 @@ module Bibliothecary
 
       def self.parse_pip(info)
         dependencies = YAML.load(info.contents)["dependencies"]
-        pip = dependencies.find { |dep| dep.is_a?(Hash) && dep.dig("pip")}
+        pip = dependencies.find { |dep| dep.is_a?(Hash) && dep["pip"]}
         return unless pip
 
         Bibliothecary::Analyser.create_analysis(

--- a/lib/bibliothecary/parsers/conda.rb
+++ b/lib/bibliothecary/parsers/conda.rb
@@ -43,7 +43,7 @@ module Bibliothecary
       def self.parse_pip(info)
         dependencies = YAML.load(info.contents)["dependencies"]
         pip = dependencies.find { |dep| dep.is_a?(Hash) && dep.dig("pip")}
-        return nil unless pip
+        return unless pip
 
         Bibliothecary::Analyser.create_analysis(
           "pypi",

--- a/lib/bibliothecary/parsers/conda.rb
+++ b/lib/bibliothecary/parsers/conda.rb
@@ -21,7 +21,7 @@ module Bibliothecary
       def self.analyse_contents_from_info(info)
         results = call_conda_parser_web(info.contents)
 
-        FILE_KINDS.map do |kind|
+        analyses = FILE_KINDS.map do |kind|
           Bibliothecary::Analyser.create_analysis(
             "conda",
             info.relative_path,
@@ -29,11 +29,29 @@ module Bibliothecary
             results[kind].map { |dep| dep.slice(:name, :requirement).merge(type: "runtime") }
           )
         end
+
+        pip_dependencies = parse_pip(info)
+        analyses <<  pip_dependencies if pip_dependencies
+
+        analyses
       rescue Bibliothecary::RemoteParsingError => e
         Bibliothecary::Analyser::create_error_analysis(platform_name, info.relative_path, "runtime", e.message)
       end
 
       private
+
+      def self.parse_pip(info)
+        dependencies = YAML.load(info.contents).dig("dependencies")
+        pip = dependencies.find { |dep| dep.is_a?(Hash) && dep.dig("pip")}
+        return nil unless pip
+
+        Bibliothecary::Analyser.create_analysis(
+          "pypi",
+          info.relative_path,
+          "manifest",
+          Pypi.parse_requirements_txt(pip["pip"].join("\n"))
+        )
+      end
 
       def self.call_conda_parser_web(file_contents)
         host = Bibliothecary.configuration.conda_parser_host

--- a/lib/bibliothecary/parsers/conda.rb
+++ b/lib/bibliothecary/parsers/conda.rb
@@ -19,14 +19,7 @@ module Bibliothecary
 
       # Overrides Analyser.analyse_contents_from_info
       def self.analyse_contents_from_info(info)
-
-        conda_results = parse_conda(info)
-        pip_results = parse_pip(info)
-
-        file_analyses = []
-        file_analyses.push(conda_results)
-        file_analyses.push(pip_results)
-        file_analyses.flatten.compact
+        [parse_conda(info), parse_pip(info)].flatten.compact
       rescue Bibliothecary::RemoteParsingError => e
         Bibliothecary::Analyser::create_error_analysis(platform_name, info.relative_path, "runtime", e.message)
       rescue Psych::SyntaxError => e

--- a/spec/fixtures/conda_with_pip/environment.yml
+++ b/spec/fixtures/conda_with_pip/environment.yml
@@ -1,0 +1,9 @@
+name: testingenv
+channels:
+  - defaults
+dependencies:
+  - pip
+  - pip:
+      - urllib3
+      - Django==2.0.0
+  - sqlite=3.29.0=h7b6447c_0

--- a/spec/fixtures/conda_with_pip/environment.yml
+++ b/spec/fixtures/conda_with_pip/environment.yml
@@ -6,4 +6,5 @@ dependencies:
   - pip:
       - urllib3
       - Django==2.0.0
+        - git+https://github.com/blaze/dask.git#egg=dask[complete]
   - sqlite=3.29.0=h7b6447c_0

--- a/spec/fixtures/conda_with_pip/environment.yml
+++ b/spec/fixtures/conda_with_pip/environment.yml
@@ -6,6 +6,4 @@ dependencies:
   - pip:
       - urllib3
       - Django==2.0.0
-      - git+https://github.com/blaze/dask.git#egg=dask[complete]
-      - -e .
   - sqlite=3.29.0=h7b6447c_0

--- a/spec/fixtures/conda_with_pip/environment.yml
+++ b/spec/fixtures/conda_with_pip/environment.yml
@@ -6,5 +6,6 @@ dependencies:
   - pip:
       - urllib3
       - Django==2.0.0
-        - git+https://github.com/blaze/dask.git#egg=dask[complete]
+      - git+https://github.com/blaze/dask.git#egg=dask[complete]
+      - -e .
   - sqlite=3.29.0=h7b6447c_0

--- a/spec/parsers/conda_spec.rb
+++ b/spec/parsers/conda_spec.rb
@@ -69,6 +69,59 @@ describe Bibliothecary::Parsers::Conda do
     )
   end
 
+  it 'parses dependencies from environment.yml with pip', :vcr do
+    expect(described_class.analyse_contents('conda_with_pip/environment.yml', load_fixture('conda_with_pip/environment.yml'))).to eq([
+       {
+           :platform=>"conda",
+           :path=>"conda_with_pip/environment.yml",
+           :dependencies=>[
+               {:name=>"pip", :requirement=>"19.2.2", :type=>"runtime"},
+               {:name=>"sqlite", :requirement=>"3.29.0", :type=>"runtime"}
+           ],
+           kind: "manifest",
+           success: true
+       },
+       {
+           :platform=>"conda",
+           :path=>"conda_with_pip/environment.yml",
+           :dependencies=>[
+               {:name=>"_libgcc_mutex", :requirement=>"0.1", :type=>"runtime"},
+               {:name=>"ca-certificates", :requirement=>"2019.5.15", :type=>"runtime"},
+               {:name=>"certifi", :requirement=>"2019.6.16", :type=>"runtime"},
+               {:name=>"libedit", :requirement=>"3.1.20181209", :type=>"runtime"},
+               {:name=>"libffi", :requirement=>"3.2.1", :type=>"runtime"},
+               {:name=>"libgcc-ng", :requirement=>"9.1.0", :type=>"runtime"},
+               {:name=>"libstdcxx-ng", :requirement=>"9.1.0", :type=>"runtime"},
+               {:name=>"ncurses", :requirement=>"6.1", :type=>"runtime"},
+               {:name=>"openssl", :requirement=>"1.1.1c", :type=>"runtime"},
+               {:name=>"pip", :requirement=>"19.2.2", :type=>"runtime"},
+               {:name=>"python", :requirement=>"3.7.4", :type=>"runtime"},
+               {:name=>"readline", :requirement=>"7.0", :type=>"runtime"},
+               {:name=>"setuptools", :requirement=>"41.0.1", :type=>"runtime"},
+               {:name=>"sqlite", :requirement=>"3.29.0", :type=>"runtime"},
+               {:name=>"tk", :requirement=>"8.6.8", :type=>"runtime"},
+               {:name=>"wheel", :requirement=>"0.33.4", :type=>"runtime"},
+               {:name=>"xz", :requirement=>"5.2.4", :type=>"runtime"},
+               {:name=>"zlib", :requirement=>"1.2.11", :type=>"runtime"},
+           ],
+           kind: "lockfile",
+           success: true
+       },
+       {
+           :platform=>"pypi",
+           :path=>"conda_with_pip/environment.yml",
+           :dependencies=>[
+               {:name=>"urllib3", :requirement=>"*", :type=>"runtime"},
+               {:name=>"Django", :requirement=>"==2.0.0", :type=>"runtime"},
+
+           ],
+           kind: "manifest",
+           success: true
+       }
+   ]
+  )
+  end
+
   it 'matches valid manifest filepaths' do
     expect(described_class.match?('environment.yml')).to be_truthy
   end

--- a/spec/vcr/Bibliothecary_Parsers_Conda/parses_dependencies_from_environment_yml_with_pip.yml
+++ b/spec/vcr/Bibliothecary_Parsers_Conda/parses_dependencies_from_environment_yml_with_pip.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://conda.libraries.io/parse
+    body:
+      encoding: UTF-8
+      string: file=name%3A%20testingenv%0Achannels%3A%0A%20%20-%20defaults%0Adependencies%3A%0A%20%20-%20pip%0A%20%20-%20sqlite%3D3.29.0%3Dh7b6447c_0%0A%20%20-%20pip%3A%0A%20%20%20%20-%20urllib3&filename=environment.yml
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Contenttype:
+      - multipart/form-data
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - gunicorn/19.9.0
+      Date:
+      - Tue, 27 Aug 2019 17:55:06 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '887'
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - clear
+    body:
+      encoding: UTF-8
+      string: '{"channels":["defaults"],"lockfile":[{"name":"_libgcc_mutex","requirement":"0.1"},{"name":"ca-certificates","requirement":"2019.5.15"},{"name":"certifi","requirement":"2019.6.16"},{"name":"libedit","requirement":"3.1.20181209"},{"name":"libffi","requirement":"3.2.1"},{"name":"libgcc-ng","requirement":"9.1.0"},{"name":"libstdcxx-ng","requirement":"9.1.0"},{"name":"ncurses","requirement":"6.1"},{"name":"openssl","requirement":"1.1.1c"},{"name":"pip","requirement":"19.2.2"},{"name":"python","requirement":"3.7.4"},{"name":"readline","requirement":"7.0"},{"name":"setuptools","requirement":"41.0.1"},{"name":"sqlite","requirement":"3.29.0"},{"name":"tk","requirement":"8.6.8"},{"name":"wheel","requirement":"0.33.4"},{"name":"xz","requirement":"5.2.4"},{"name":"zlib","requirement":"1.2.11"}],"manifest":[{"name":"pip","requirement":"19.2.2"},{"name":"sqlite","requirement":"3.29.0"}]}
+
+        '
+    http_version: 
+  recorded_at: Tue, 27 Aug 2019 17:55:06 GMT
+recorded_with: VCR 5.0.0


### PR DESCRIPTION
This checks for a `- pip:` entry in the yaml, and then parses that as "requirements.txt" data, returning an Analysis for that with the Condas data.


Not sure if this is the right approach, but it seems to work.