### PR TITLE
fix Update reference in .csproj #478

### DIFF
--- a/lib/bibliothecary/parsers/nuget.rb
+++ b/lib/bibliothecary/parsers/nuget.rb
@@ -91,7 +91,7 @@ module Bibliothecary
 
       def self.parse_csproj(file_contents)
         manifest = Ox.parse file_contents
-        packages = manifest.locate('ItemGroup/PackageReference').map do |dependency|
+        packages = manifest.locate('ItemGroup/PackageReference').select{ |dep| dep.respond_to? "Include" }.map do |dependency|
           {
             name: dependency.Include,
             requirement: (dependency.Version if dependency.respond_to? "Version") || "*",

--- a/spec/fixtures/example-update.csproj
+++ b/spec/fixtures/example-update.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETCore.App" Version="1.1.1" />
+  </ItemGroup>
+</Project>

--- a/spec/parsers/nuget_spec.rb
+++ b/spec/parsers/nuget_spec.rb
@@ -875,6 +875,19 @@ describe Bibliothecary::Parsers::Nuget do
     })
   end
 
+  it 'parses dependencies from example-update.csproj' do
+    expect(described_class.analyse_contents('example-update.csproj', load_fixture('example-update.csproj'))).to eq({
+      :platform=>"nuget",
+      :path=>"example-update.csproj",
+      :dependencies=>[
+        {:name=>"Microsoft.AspNetCore", :requirement=>"1.1.1", :type=>"runtime"},
+        {:name=>"Microsoft.AspNetCore.StaticFiles", :requirement=>"2.2.0", :type=>"runtime"}
+      ],
+      kind: 'manifest',
+      success: true
+    })
+  end
+
   it 'parses dependencies from example.nuspec' do
     expect(described_class.analyse_contents('example.nuspec', load_fixture('example.nuspec'))).to eq({
       :platform=>"nuget",


### PR DESCRIPTION
If the .csproj file has `Update` reference the analyzer fails. Because it expect only `Include` reference.

Error message: "Include not found"

Failure case
```
  <ItemGroup>
    <PackageReference Update="Microsoft.NETCore.App" Version="1.1.1" />
  </ItemGroup>
```