### PR TITLE
Pick a different framework in nuget

### DIFF
--- a/lib/bibliothecary/parsers/nuget.rb
+++ b/lib/bibliothecary/parsers/nuget.rb
@@ -70,10 +70,12 @@ module Bibliothecary
         if frameworks.size > 0
           # we should really return multiple manifests, but bibliothecary doesn't
           # do that yet so at least pick deterministically.
-          frameworks[frameworks.keys.sort.last]
-        else
-          []
+
+          # Note, frameworks can be empty, so remove empty ones and then return the last sorted item if any
+          frameworks = frameworks.delete_if { |k, v| v.empty? }
+          return frameworks[frameworks.keys.sort.last] unless frameworks.empty?
         end
+        []
       end
 
       def self.parse_packages_config(file_contents)

--- a/spec/fixtures/packages.lock.json
+++ b/spec/fixtures/packages.lock.json
@@ -1,6 +1,7 @@
 {
   "version": 1,
   "dependencies": {
+    ".empty-list-earlier-alphabetically": {},
     ".NETCoreApp,Version=v2.2": {
       "Microsoft.AspNetCore.App": {
         "type": "Direct",
@@ -3099,6 +3100,7 @@
           "System.Xml.XPath": "4.3.0"
         }
       }
-    }
+    },
+    "empty-list-later-alphabetically": {}
   }
 }

--- a/spec/fixtures/packages.lock.json
+++ b/spec/fixtures/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    ".Empty-list-earlier-alphabetically": {},
+    ".Empty-group-earlier-alphabetically": {},
     ".NETCoreApp,Version=v2.2": {
       "Microsoft.AspNetCore.App": {
         "type": "Direct",
@@ -3101,6 +3101,6 @@
         }
       }
     },
-    "Empty-list-later-alphabetically": {}
+    "Empty-group-later-alphabetically": {}
   }
 }

--- a/spec/fixtures/packages.lock.json
+++ b/spec/fixtures/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    ".empty-list-earlier-alphabetically": {},
+    ".Empty-list-earlier-alphabetically": {},
     ".NETCoreApp,Version=v2.2": {
       "Microsoft.AspNetCore.App": {
         "type": "Direct",
@@ -3101,6 +3101,6 @@
         }
       }
     },
-    "empty-list-later-alphabetically": {}
+    "Empty-list-later-alphabetically": {}
   }
 }


### PR DESCRIPTION
Problem:

lockfile can have multiple frameworks.
Incidentally one we picked had the frameworks ordered that the `.last` was an empty one.
This PR deletes any empty frameworks from the frameworks hash, then returns the `.last` one of these with any values.
If there's none, continues on returning empty array.