### PR TITLE
Only match pom dep for maven properties if the field is present.

### DIFF
--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -201,7 +201,7 @@ module Bibliothecary
         return nil if field.nil?
 
         value = field.nodes.first
-        match = value.match(MAVEN_PROPERTY_REGEX)
+        match = value&.match(MAVEN_PROPERTY_REGEX)
         if match
           return extract_property(xml, match[1], value, parent_properties)
         else


### PR DESCRIPTION
Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/5ffcc76ae4560f0017add9ac