### PR TITLE
Handle nested version nodes in package references

### DIFF
--- a/lib/bibliothecary/parsers/nuget.rb
+++ b/lib/bibliothecary/parsers/nuget.rb
@@ -93,10 +93,16 @@ module Bibliothecary
 
       def self.parse_csproj(file_contents)
         manifest = Ox.parse file_contents
+
         packages = manifest.locate('ItemGroup/PackageReference').map do |dependency|
+          requirement = (dependency.Version if dependency.respond_to? "Version") || "*"
+          if requirement.is_a?(Ox::Element)
+            requirement = dependency.nodes.detect{ |n| n.value == "Version" }&.text
+          end
+
           {
             name: dependency.Include,
-            requirement: (dependency.Version if dependency.respond_to? "Version") || "*",
+            requirement: requirement,
             type: 'runtime'
           }
         end

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "6.9.7"
+  VERSION = "6.9.8"
 end

--- a/spec/fixtures/example.csproj
+++ b/spec/fixtures/example.csproj
@@ -13,5 +13,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="1.1.0" />
+    <PackageReference Include="System.Resources.Extensions">
+      <Version>4.7.0</Version>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/spec/parsers/nuget_spec.rb
+++ b/spec/parsers/nuget_spec.rb
@@ -855,7 +855,8 @@ describe Bibliothecary::Parsers::Nuget do
         {:name=>"Microsoft.AspNetCore.StaticFiles", :requirement=>"1.1.1", :type=>"runtime"},
         {:name=>"Microsoft.Extensions.Logging.Debug", :requirement=>"1.1.1", :type=>"runtime"},
         {:name=>"Microsoft.Extensions.DependencyInjection", :requirement=>"1.1.1", :type=>"runtime"},
-        {:name=>"Microsoft.VisualStudio.Web.BrowserLink", :requirement=>"1.1.0", :type=>"runtime"}
+        {:name=>"Microsoft.VisualStudio.Web.BrowserLink", :requirement=>"1.1.0", :type=>"runtime"},
+        {:name=>"System.Resources.Extensions", :requirement=>"4.7.0", :type=>"runtime"}
       ],
       kind: 'manifest',
       success: true


### PR DESCRIPTION
Sometimes Versions show up as nodes instead of attributes 🤷 