### PR TITLE
Add pip parsing to conda environment yaml files

### DIFF
--- a/lib/bibliothecary.rb
+++ b/lib/bibliothecary.rb
@@ -21,8 +21,8 @@ module Bibliothecary
     runner.load_file_list(path)
   end
 
-  def self.init_package_manager(info)
-    runner.init_package_manager(info)
+  def self.applicable_package_managers(info)
+    runner.applicable_package_managers(info)
   end
 
   def self.load_file_info_list(path)

--- a/lib/bibliothecary/parsers/conda.rb
+++ b/lib/bibliothecary/parsers/conda.rb
@@ -26,14 +26,35 @@ module Bibliothecary
         }
       end
 
-      def self.parse_conda(info)
-        dependencies = call_conda_parser_web(info, "manifest")[:manifest]
+      # Overrides Analyser.analyse_contents_from_info
+      def self.analyse_contents_from_info(info)
+        [super, parse_pip(info)].flatten.compact
+      rescue Bibliothecary::RemoteParsingError => e
+        Bibliothecary::Analyser::create_error_analysis(platform_name, info.relative_path, "runtime", e.message)
+      rescue Psych::SyntaxError => e
+        Bibliothecary::Analyser::create_error_analysis(platform_name, info.relative_path, "runtime", e.message)
+      end
+
+      def self.parse_conda(info, kind = "manifest")
+        dependencies = call_conda_parser_web(info, kind)[kind.to_sym]
         dependencies.map { |dep| dep.merge(type: "runtime") }
       end
 
       def self.parse_conda_lockfile(info)
-        dependencies = call_conda_parser_web(info, "lockfile")[:lockfile]
-        dependencies.map { |dep| dep.merge(type: "runtime") }
+        parse_conda(info, "lockfile")
+      end
+
+      def self.parse_pip(info)
+        dependencies = YAML.safe_load(info.contents)["dependencies"]
+        pip = dependencies.find { |dep| dep.is_a?(Hash) && dep["pip"]}
+        return unless pip
+
+        Bibliothecary::Analyser.create_analysis(
+          "pypi",
+          info.relative_path,
+          "manifest",
+          Pypi.parse_requirements_txt(pip["pip"].join("\n"))
+        )
       end
 
       private_class_method def self.call_conda_parser_web(file_contents, kind)

--- a/lib/bibliothecary/runner.rb
+++ b/lib/bibliothecary/runner.rb
@@ -32,14 +32,8 @@ module Bibliothecary
       load_file_info_list(path).map { |info| info.full_path }
     end
 
-    def init_package_manager(info)
-      # set the package manager on each info
-      matches = package_managers.select { |pm| pm.match_info?(info) }
-
-      info.package_manager = matches[0] if matches.length == 1
-
-      # this is a bug at the moment if it's raised (we don't handle it sensibly)
-      raise "Multiple package managers fighting over #{info.relative_path}: #{matches.map(&:to_s)}" if matches.length > 1
+    def applicable_package_managers(info)
+      package_managers.select { |pm| pm.match_info?(info) }
     end
 
     def package_managers
@@ -48,29 +42,41 @@ module Bibliothecary
 
     def load_file_info_list_from_paths(paths)
       file_list = []
+
       paths.each do |path|
         info = FileInfo.new(nil, path)
 
         next if ignored_files.include?(info.relative_path)
 
-        init_package_manager(info)
-        file_list.push(info)
+        applicable_package_managers(info).each do |package_manager|
+          file = info.dup
+          file.package_manager = package_manager
+
+          file_list.push(file)
+        end
       end
+
       file_list
     end
 
     def load_file_info_list(path)
       file_list = []
+
       Find.find(path) do |subpath|
         info = FileInfo.new(path, subpath)
+
         Find.prune if FileTest.directory?(subpath) && ignored_dirs.include?(info.relative_path)
         next unless FileTest.file?(subpath)
         next if ignored_files.include?(info.relative_path)
 
-        init_package_manager(info)
+        applicable_package_managers(info).each do |package_manager|
+          file = info.dup
+          file.package_manager = package_manager
 
-        file_list.push(info)
+          file_list.push(file)
+        end
       end
+
       file_list
     end
 

--- a/lib/bibliothecary/runner.rb
+++ b/lib/bibliothecary/runner.rb
@@ -33,7 +33,8 @@ module Bibliothecary
     end
 
     def applicable_package_managers(info)
-      package_managers.select { |pm| pm.match_info?(info) }
+      managers = package_managers.select { |pm| pm.match_info?(info) }
+      managers.length > 0 ? managers : [nil]
     end
 
     def package_managers

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "6.10.7"
+  VERSION = "6.11.0"
 end

--- a/spec/bibliothecary_spec.rb
+++ b/spec/bibliothecary_spec.rb
@@ -245,7 +245,14 @@ describe Bibliothecary do
         :dependencies=>[],
         :kind=>"lockfile",
         success: true,
-        :related_paths=>["subdir/Gemfile"]}])
+        :related_paths=>["subdir/Gemfile"]},
+      {:platform=>"unknown",
+        :path=>"unknown_non_manifest.txt",
+        :dependencies=>[],
+        :kind=>"unknown",
+        :success=>false,
+        :error_message=>"No parser for this file type"}
+      ])
 
     Bibliothecary.reset
   end

--- a/spec/bibliothecary_spec.rb
+++ b/spec/bibliothecary_spec.rb
@@ -172,7 +172,7 @@ describe Bibliothecary do
     Bibliothecary.reset
   end
 
-  it 'handles a complicated folder with many manifests complaining about no-parser files', :vcr do
+  it 'handles a complicated folder with many manifests', :vcr do
     # If we run the analysis in pwd, confusion about absolute vs.
     # relative paths is concealed because both work
     orig_pwd = Dir.pwd
@@ -245,13 +245,38 @@ describe Bibliothecary do
         :dependencies=>[],
         :kind=>"lockfile",
         success: true,
-        :related_paths=>["subdir/Gemfile"]},
-       {:platform=>"unknown",
-        :path=>"unknown_non_manifest.txt",
-        :dependencies=>[],
-        :kind=>"unknown",
-        :success=>false,
-        :error_message=>"No parser for this file type"}])
+        :related_paths=>["subdir/Gemfile"]}])
+
+    Bibliothecary.reset
+  end
+
+  it 'handles a dual-platformed file (pip/conda)', :vcr do
+    # If we run the analysis in pwd, confusion about absolute vs.
+    # relative paths is concealed because both work
+    orig_pwd = Dir.pwd
+    analysis = Dir.chdir("/") do
+      described_class.analyse(File.join(orig_pwd, 'spec/fixtures/conda_with_pip'))
+    end
+    # empty out any dependencies to make the test more reliable.
+    # we test specific manifest parsers in the parsers specs
+    analysis.each do |a|
+      a[:dependencies] = []
+    end
+
+    expect(analysis).to eq(
+      [{ dependencies: [],
+          kind: "manifest",
+          path: "environment.yml",
+          platform: "conda",
+          related_paths: [],
+          success: true },
+        { dependencies: [],
+          kind: "manifest",
+          path: "environment.yml",
+          platform: "pypi",
+          related_paths: [],
+          success: true }]
+    )
 
     Bibliothecary.reset
   end

--- a/spec/parsers/conda_spec.rb
+++ b/spec/parsers/conda_spec.rb
@@ -73,37 +73,6 @@ describe Bibliothecary::Parsers::Conda do
     )
   end
 
-  it "parses dependencies from environment.yml.lock with pip", :vcr do
-    expect(described_class.analyse_contents("conda_with_pip/environment.yml.lock", load_fixture("conda_with_pip/environment.yml"))).to eq(
-      {
-        :platform=>"conda",
-        :path=>"conda_with_pip/environment.yml.lock",
-        :dependencies=>[
-        {:name=>"_libgcc_mutex", :requirement=>"0.1", :type=>"runtime"},
-        {:name=>"ca-certificates", :requirement=>"2019.8.28", :type=>"runtime"},
-        {:name=>"certifi", :requirement=>"2019.9.11", :type=>"runtime"},
-        {:name=>"libedit", :requirement=>"3.1.20181209", :type=>"runtime"},
-        {:name=>"libffi", :requirement=>"3.2.1", :type=>"runtime"},
-        {:name=>"libgcc-ng", :requirement=>"9.1.0", :type=>"runtime"},
-        {:name=>"libstdcxx-ng", :requirement=>"9.1.0", :type=>"runtime"},
-        {:name=>"ncurses", :requirement=>"6.1", :type=>"runtime"},
-        {:name=>"openssl", :requirement=>"1.1.1d", :type=>"runtime"},
-        {:name=>"pip", :requirement=>"19.2.3", :type=>"runtime"},
-        {:name=>"python", :requirement=>"3.7.4", :type=>"runtime"},
-        {:name=>"readline", :requirement=>"7.0", :type=>"runtime"},
-        {:name=>"setuptools", :requirement=>"41.2.0", :type=>"runtime"},
-        {:name=>"sqlite", :requirement=>"3.29.0", :type=>"runtime"},
-        {:name=>"tk", :requirement=>"8.6.8", :type=>"runtime"},
-        {:name=>"wheel", :requirement=>"0.33.6", :type=>"runtime"},
-        {:name=>"xz", :requirement=>"5.2.4", :type=>"runtime"},
-        {:name=>"zlib", :requirement=>"1.2.11", :type=>"runtime"}
-        ],
-        kind: "lockfile",
-        success: true
-       }
-    )
-  end
-
   it "matches valid manifest filepaths" do
     expect(described_class.match?("environment.yml")).to be_truthy
   end

--- a/spec/parsers/pypi_spec.rb
+++ b/spec/parsers/pypi_spec.rb
@@ -107,6 +107,21 @@ describe Bibliothecary::Parsers::Pypi do
     })
   end
 
+  it "parses dependencies from conda environment.yml.lock with pip" do
+    expect(described_class.analyse_contents("conda_with_pip/environment.yml.lock", load_fixture("conda_with_pip/environment.yml"))).to eq(
+      {
+        :platform=>"pypi",
+        :path=>"conda_with_pip/environment.yml.lock",
+        :dependencies=>[
+          {:name=>"urllib3", :requirement=>"*", :type=>"runtime"},
+          {:name=>"Django", :requirement=>"==2.0.0", :type=>"runtime"},
+        ],
+        kind: "lockfile",
+        success: true
+       }
+    )
+  end
+
   it 'matches valid manifest filepaths' do
     expect(described_class.match?('requirements.txt')).to be_truthy
     expect(described_class.match?('requirements.pip')).to be_truthy

--- a/spec/vcr/Bibliothecary/handles_a_dual-platformed_file_pip/conda_.yml
+++ b/spec/vcr/Bibliothecary/handles_a_dual-platformed_file_pip/conda_.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://conda-parser.libraries.io/parse
+    body:
+      encoding: UTF-8
+      string: file=name%3A%20testingenv%0Achannels%3A%0A%20%20-%20defaults%0Adependencies%3A%0A%20%20-%20pip%0A%20%20-%20pip%3A%0A%20%20%20%20%20%20-%20urllib3%0A%20%20%20%20%20%20-%20Django%3D%3D2.0.0%0A%20%20-%20sqlite%3D3.29.0%3Dh7b6447c_0%0A&filename=environment.yml
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Contenttype:
+      - multipart/form-data
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server:
+      - gunicorn/19.9.0
+      Date:
+      - Tue, 11 May 2021 16:48:25 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '143'
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - clear
+    body:
+      encoding: ASCII-8BIT
+      string: '{"bad_specs":[],"channels":["defaults"],"lockfile":null,"manifest":[{"name":"pip","requirement":""},{"name":"sqlite","requirement":"3.29.0"}]}
+
+'
+    http_version: null
+  recorded_at: Tue, 11 May 2021 16:48:25 GMT
+recorded_with: VCR 5.1.0


### PR DESCRIPTION
Trying out a bit of a hybrid approach where we rely on conda-parser for the primary conda bits, and then added some of the previous code back for parsing pip-in-conda dependencies. I have to dig in a little more here, because I don't think Bibliothecary#analyse_file should be producing an array. 

I'm wondering if we should have the pypi parser do this and figure out some way to let both parsers have at the file.