### PR TITLE
maven-dependency-tree.txt: prevent package name from being listed as a dep.

### DIFF
--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -152,9 +152,12 @@ module Bibliothecary
           .compact
           .uniq
       end
+
       def self.parse_maven_tree(file_contents)
         file_contents = file_contents.gsub(/\r\n?/, "\n")
         captures = file_contents.scan(/^\[INFO\](?:(?:\+-)|\||(?:\\-)|\s)+((?:[\w\.-]+:)+[\w\.\-${}]+)/).flatten.uniq
+        captures.shift if captures.size > 1 # first dep line will be the package itself (unless we're only analyzing a single line)
+
         captures.map do |item|
           parts = item.split(":")
           case parts.count

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,4 +1,3 @@
 module Bibliothecary
-  VERSION = "6.12.3"
   VERSION = "7.0.1"
 end

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "6.12.2"
+  VERSION = "6.12.3"
 end

--- a/spec/fixtures/maven-dependency-tree.txt
+++ b/spec/fixtures/maven-dependency-tree.txt
@@ -56,6 +56,7 @@
 [INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ pmd-core ---
 [INFO] net.sourceforge.pmd:pmd-core:jar:6.32.0-SNAPSHOT
 [INFO] +- org.apache.ant:ant:jar:1.10.9:provided
+[INFO] -  +- net.sourceforge.pmd:pmd:pom:6.32.0-SNAPSHOT
 [INFO] |  \- org.apache.ant:ant-launcher:jar:1.10.9:provided
 [INFO] +- net.java.dev.javacc:javacc:jar:5.0:provided
 [INFO] +- org.antlr:antlr4-runtime:jar:4.7.2:compile

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -422,16 +422,17 @@ RSpec.describe Bibliothecary::Parsers::Maven do
     it "parses dependencies from maven-dependency-tree files" do
       contents = load_fixture("maven-dependency-tree.txt")
       output = described_class.parse_maven_tree(contents)
-      expect(output.count).to eq 315
-      expect(output.find {|item| item[:name] == "org.apache.commons:commons-lang3"}[:requirement]).to eq "3.8.1"
+      expect(output.count).to eq 314
+      expect(output.find { |item| item[:name] == "org.apache.commons:commons-lang3"}[:requirement]).to eq "3.8.1"
+      expect(output.find { |item| item[:name] == "net.sourceforge.pmd:pmd" }).to eq(nil)
     end
 
     it "parses dependencies with windows line endings" do
       contents = load_fixture("maven-dependency-tree.txt")
       contents = contents.gsub("\n", "\r\n")
       output = described_class.parse_maven_tree(contents)
-      expect(output.count).to eq 315
-      expect(output.find {|item| item[:name] == "org.apache.commons:commons-lang3"}[:requirement]).to eq "3.8.1"
+      expect(output.count).to eq 314
+      expect(output.find { |item| item[:name] == "org.apache.commons:commons-lang3"}[:requirement]).to eq "3.8.1"
     end
 
     it "parses dependencies with variables in version position" do


### PR DESCRIPTION
When parsing a `maven-dependency-tree.txt`, the first dep will be the package you're parsing. This skips that first dep so it's not counted as a dep of itself. 