### PR TITLE
Update toml library for ruby 3 compatibility

### DIFF
--- a/bibliothecary.gemspec
+++ b/bibliothecary.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "toml-rb", "~> 1.0"
+  spec.add_dependency "tomlrb", "~> 2.0"
   spec.add_dependency "librariesio-gem-parser"
   spec.add_dependency "ox", ">= 2.8.1"
   spec.add_dependency "typhoeus"

--- a/lib/bibliothecary.rb
+++ b/lib/bibliothecary.rb
@@ -6,6 +6,7 @@ require "bibliothecary/exceptions"
 require "bibliothecary/file_info"
 require "bibliothecary/related_files_info"
 require "find"
+require "tomlrb"
 
 Dir[File.expand_path('../bibliothecary/parsers/*.rb', __FILE__)].each do |file|
   require file

--- a/lib/bibliothecary/parsers/cargo.rb
+++ b/lib/bibliothecary/parsers/cargo.rb
@@ -1,5 +1,3 @@
-require 'toml-rb'
-
 module Bibliothecary
   module Parsers
     class Cargo
@@ -19,7 +17,7 @@ module Bibliothecary
       end
 
       def self.parse_manifest(file_contents)
-        manifest = TomlRB.parse(file_contents)
+        manifest = Tomlrb.parse(file_contents)
         manifest.fetch('dependencies', []).map do |name, requirement|
           if requirement.respond_to?(:fetch)
             requirement = requirement['version'] or next
@@ -34,7 +32,7 @@ module Bibliothecary
       end
 
       def self.parse_lockfile(file_contents)
-        manifest = TomlRB.parse(file_contents)
+        manifest = Tomlrb.parse(file_contents)
         manifest.fetch('package',[]).map do |dependency|
           next if not dependency['source'] or not dependency['source'].start_with?('registry+')
           {

--- a/lib/bibliothecary/parsers/go.rb
+++ b/lib/bibliothecary/parsers/go.rb
@@ -106,12 +106,12 @@ module Bibliothecary
       end
 
       def self.parse_dep_toml(file_contents)
-        manifest = TomlRB.parse file_contents
+        manifest = Tomlrb.parse file_contents
         map_dependencies(manifest, 'constraint', 'name', 'version', 'runtime')
       end
 
       def self.parse_dep_lockfile(file_contents)
-        manifest = TomlRB.parse file_contents
+        manifest = Tomlrb.parse file_contents
         map_dependencies(manifest, 'projects', 'name', 'revision', 'runtime')
       end
 

--- a/lib/bibliothecary/parsers/pypi.rb
+++ b/lib/bibliothecary/parsers/pypi.rb
@@ -61,12 +61,12 @@ module Bibliothecary
       end
 
       def self.parse_pipfile(file_contents)
-        manifest = TomlRB.parse(file_contents)
+        manifest = Tomlrb.parse(file_contents)
         map_dependencies(manifest['packages'], 'runtime') + map_dependencies(manifest['dev-packages'], 'develop')
       end
 
       def self.parse_poetry(file_contents)
-        manifest = TomlRB.parse(file_contents)['tool']['poetry']
+        manifest = Tomlrb.parse(file_contents)['tool']['poetry']
         map_dependencies(manifest['dependencies'], 'runtime') + map_dependencies(manifest['dev-dependencies'], 'develop')
       end
 
@@ -124,7 +124,7 @@ module Bibliothecary
       end
 
       def self.parse_poetry_lock(file_contents)
-        manifest = TomlRB.parse(file_contents)
+        manifest = Tomlrb.parse(file_contents)
         deps = []
         manifest["package"].each do |package|
           # next if group == "_meta"

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "6.12.3"
+  VERSION = "7.0.0"
 end


### PR DESCRIPTION
Citrus/toml-rb was segfaulting on ruby 3.0. I saw an open issue but didn't dig super hard since we can just swap libraries and things work just fine. https://github.com/mjackson/citrus/issues/60
