### PR TITLE
parse_maven_tree: ignore package type when removing package from list

### DIFF
--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -175,7 +175,7 @@ module Bibliothecary
 
         # First dep line will be the package itself (unless we're only analyzing a single line)
         package = deps[0]
-        deps.size == 1 ? deps : deps[1..-1].reject { |d| d[:name] == package[:name] && d[:requirement] == package[:requirement] }
+        deps.size < 2 ? deps : deps[1..-1].reject { |d| d[:name] == package[:name] && d[:requirement] == package[:requirement] }
       end
 
       def self.parse_resolved_dep_line(line)

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -156,9 +156,8 @@ module Bibliothecary
       def self.parse_maven_tree(file_contents)
         file_contents = file_contents.gsub(/\r\n?/, "\n")
         captures = file_contents.scan(/^\[INFO\](?:(?:\+-)|\||(?:\\-)|\s)+((?:[\w\.-]+:)+[\w\.\-${}]+)/).flatten.uniq
-        captures.shift if captures.size > 1 # first dep line will be the package itself (unless we're only analyzing a single line)
 
-        captures.map do |item|
+        deps = captures.map do |item|
           parts = item.split(":")
           case parts.count
           when 4
@@ -173,6 +172,10 @@ module Bibliothecary
             type: type
           }
         end
+
+        # First dep line will be the package itself (unless we're only analyzing a single line)
+        package = deps[0]
+        deps.size == 1 ? deps : deps[1..-1].reject { |d| d[:name] == package[:name] && d[:requirement] == package[:requirement] }
       end
 
       def self.parse_resolved_dep_line(line)

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "7.0.1"
+  VERSION = "7.0.2"
 end

--- a/spec/fixtures/maven-dependency-tree.txt
+++ b/spec/fixtures/maven-dependency-tree.txt
@@ -56,7 +56,7 @@
 [INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ pmd-core ---
 [INFO] net.sourceforge.pmd:pmd-core:jar:6.32.0-SNAPSHOT
 [INFO] +- org.apache.ant:ant:jar:1.10.9:provided
-[INFO] -  +- net.sourceforge.pmd:pmd:pom:6.32.0-SNAPSHOT
+[INFO] |  +- net.sourceforge.pmd:pmd:pom:6.32.0-SNAPSHOT:provided
 [INFO] |  \- org.apache.ant:ant-launcher:jar:1.10.9:provided
 [INFO] +- net.java.dev.javacc:javacc:jar:5.0:provided
 [INFO] +- org.antlr:antlr4-runtime:jar:4.7.2:compile


### PR DESCRIPTION
When [removing the package itself from a maven dep tree](https://github.com/librariesio/bibliothecary/pull/505), we should treat  `GROUP:NAME:SOURCE:VERSION:TYPE` the same if `TYPE` differs.