### PR TITLE
Add support for Drupal Composer repo by returning Drupal version.

### DIFF
--- a/lib/bibliothecary/parsers/packagist.rb
+++ b/lib/bibliothecary/parsers/packagist.rb
@@ -21,15 +21,17 @@ module Bibliothecary
       def self.parse_lockfile(file_contents)
         manifest = JSON.parse file_contents
         manifest.fetch('packages',[]).map do |dependency|
+          requirement = is_drupal_module(dependency) ? dependency.dig("source", "reference") : dependency["version"]
           {
             name: dependency["name"],
-            requirement: dependency["version"],
+            requirement: requirement,
             type: 'runtime'
           }
         end + manifest.fetch('packages-dev',[]).map do |dependency|
+          requirement = is_drupal_module(dependency) ? dependency.dig("source", "reference") : dependency["version"]
           {
             name: dependency["name"],
-            requirement: dependency["version"],
+            requirement: requirement,
             type: 'development'
           }
         end
@@ -39,6 +41,15 @@ module Bibliothecary
         manifest = JSON.parse file_contents
         map_dependencies(manifest, 'require', 'runtime') +
         map_dependencies(manifest, 'require-dev', 'development')
+      end
+
+      # Drupal hosts its own Composer repository, where its "modules" are indexed and searchable. The best way to
+      # confirm that Drupal's repo is being used is if its in the "repositories" in composer.json (https://support.acquia.com/hc/en-us/articles/360048081273-Using-Composer-to-manage-dependencies-in-Drupal-8-and-9),
+      # but you may only have composer.lock, so we test if the type is "drupal-*" (e.g. "drupal-module" or "drupal-theme")
+      # The Drupal team also setup its own mapper of Composer semver -> Drupal tool-specfic versions  (https://www.drupal.org/project/project_composer/issues/2622450),
+      # so we return the Drupal requirement instead of semver requirement if it's here.
+      private_class_method def self.is_drupal_module(dependency)
+        dependency["type"] =~ /drupal/ && dependency.dig("source", "reference")
       end
     end
   end

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "7.1.0"
+  VERSION = "7.0.2"
 end

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "7.0.2"
+  VERSION = "7.1.0"
 end

--- a/spec/fixtures/composer.json
+++ b/spec/fixtures/composer.json
@@ -5,7 +5,8 @@
 	"license": "MIT",
 	"type": "project",
 	"require": {
-		"laravel/framework": "5.0.*"
+		"laravel/framework": "5.0.*",
+		"drupal/address": "^1.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.0",
@@ -19,10 +20,11 @@
 			"App\\": "app/"
 		}
 	},
-	"autoload-dev": {
-		"classmap": [
-			"tests/TestCase.php"
-		]
+	"repositories": {
+		"drupal": {
+				"type": "composer",
+				"url": "https://packages.drupal.org/8"
+		}
 	},
 	"scripts": {
 		"post-install-cmd": [

--- a/spec/fixtures/composer.lock
+++ b/spec/fixtures/composer.lock
@@ -212,6 +212,45 @@
             "time": "2014-02-03 23:07:43"
         },
         {
+            "name": "drupal/address",
+            "version": "1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/address.git",
+                "reference": "8.x-1.9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/address-8.x-1.9.zip",
+                "reference": "8.x-1.9",
+                "shasum": "c7e6406d88c6d6be9e8fe0091040d67012bdbf05"
+            },
+            "require": {},
+            "require-dev": {},
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.9",
+                    "datestamp": "1604422821",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+            ],
+            "description": "Provides functionality for storing, validating and displaying international postal addresses.",
+            "homepage": "http://drupal.org/project/address",
+            "support": {
+                "source": "https://git.drupalcode.org/project/address"
+            }
+        },
+        {
             "name": "symfony/monolog-bundle",
             "version": "v2.6.1",
             "source": {

--- a/spec/parsers/packagist_spec.rb
+++ b/spec/parsers/packagist_spec.rb
@@ -28,7 +28,7 @@ describe Bibliothecary::Parsers::Packagist do
         {:name=>"doctrine/annotations", :requirement=>"v1.2.1", :type=>"runtime"},
         {:name=>"doctrine/cache", :requirement=>"v1.3.1", :type=>"runtime"},
         {:name=>"doctrine/collections", :requirement=>"v1.2", :type=>"runtime"},
-        {:name=>"drupal/address", :requirement=>"8.x-1.9", :type=>"runtime"},
+        {:name=>"drupal/address", :requirement=>"8.x-1.9", :original_requirement => "1.9.0", :type=>"runtime"},
         {:name=>"symfony/monolog-bundle", :requirement=>"v2.6.1", :type=>"runtime"},
         {:name=>"symfony/swiftmailer-bundle", :requirement=>"v2.3.8", :type=>"runtime"},
         {:name=>"symfony/symfony", :requirement=>"v2.6.1", :type=>"runtime"},

--- a/spec/parsers/packagist_spec.rb
+++ b/spec/parsers/packagist_spec.rb
@@ -11,6 +11,7 @@ describe Bibliothecary::Parsers::Packagist do
       :path=>"composer.json",
       :dependencies=>[
         {:name=>"laravel/framework", :requirement=>"5.0.*", :type=>"runtime"},
+        {:name=>"drupal/address", :requirement=>"^1.0", :type=>"runtime"},
         {:name=>"phpunit/phpunit", :requirement=>"~4.0", :type=>"development"},
         {:name=>"phpspec/phpspec", :requirement=>"~2.1", :type=>"development"}
       ],
@@ -27,12 +28,13 @@ describe Bibliothecary::Parsers::Packagist do
         {:name=>"doctrine/annotations", :requirement=>"v1.2.1", :type=>"runtime"},
         {:name=>"doctrine/cache", :requirement=>"v1.3.1", :type=>"runtime"},
         {:name=>"doctrine/collections", :requirement=>"v1.2", :type=>"runtime"},
+        {:name=>"drupal/address", :requirement=>"8.x-1.9", :type=>"runtime"},
         {:name=>"symfony/monolog-bundle", :requirement=>"v2.6.1", :type=>"runtime"},
         {:name=>"symfony/swiftmailer-bundle", :requirement=>"v2.3.8", :type=>"runtime"},
         {:name=>"symfony/symfony", :requirement=>"v2.6.1", :type=>"runtime"},
         {:name=>"twig/extensions", :requirement=>"v1.2.0", :type=>"runtime"},
         {:name=>"twig/twig", :requirement=>"v1.16.2", :type=>"runtime"},
-        {:name=>"sensio/generator-bundle", :requirement=>"v2.5.0", :type=>"development"}
+        {:name=>"sensio/generator-bundle", :requirement=>"v2.5.0", :type=>"development"},
       ],
       kind: 'lockfile',
       success: true

--- a/spec/parsers/packagist_spec.rb
+++ b/spec/parsers/packagist_spec.rb
@@ -28,7 +28,7 @@ describe Bibliothecary::Parsers::Packagist do
         {:name=>"doctrine/annotations", :requirement=>"v1.2.1", :type=>"runtime"},
         {:name=>"doctrine/cache", :requirement=>"v1.3.1", :type=>"runtime"},
         {:name=>"doctrine/collections", :requirement=>"v1.2", :type=>"runtime"},
-        {:name=>"drupal/address", :requirement=>"8.x-1.9", :original_requirement => "1.9.0", :type=>"runtime"},
+        {:name=>"drupal/address", :requirement => "1.9.0", :drupal_requirement=>"8.x-1.9", :type=>"runtime"},
         {:name=>"symfony/monolog-bundle", :requirement=>"v2.6.1", :type=>"runtime"},
         {:name=>"symfony/swiftmailer-bundle", :requirement=>"v2.3.8", :type=>"runtime"},
         {:name=>"symfony/symfony", :requirement=>"v2.6.1", :type=>"runtime"},


### PR DESCRIPTION
Drupal has a Composer repository at `https://packages.drupal.org/{7,8}`, and most Drupal packages in a Composer manifest will point to that (versus Packagist). 

However, Drupal's repository uses a mapper that translates the semver that Composer asks for into Drupal-compatible versions, e.g. `8-x.2-1` (this example translates to version `2.1.0` that is compatible with Drupal 8).

This change returns the Drupal version instead of the semver version if the package is a Drupal one.

### Example composer.lock snippet:

```
        ...
        {
            "name": "drupal/allowed_formats",
            "version": "1.3.0",
            "source": {
                "type": "git",
                "url": "https://git.drupalcode.org/project/allowed_formats.git",
                "reference": "8.x-1.3"
            },
            ...
         }
         ...
```

After this change, Bibliothecary would return `{name: "drupal/allowed_formats", requirement: "1.3.0", drupal_requirement: "8.x-1.3", type: "runtime"}` from that ^.

https://app.clubhouse.io/tidelift/story/19449/libraries-add-drupal-repository-as-a-source-of-composer-files#activity-19459