### PR TITLE
7.1.3 - Add *.in as matching manifest file

### DIFF
--- a/lib/bibliothecary/parsers/pypi.rb
+++ b/lib/bibliothecary/parsers/pypi.rb
@@ -6,7 +6,7 @@ module Bibliothecary
       INSTALL_REGEXP = /install_requires\s*=\s*\[([\s\S]*?)\]/
       REQUIRE_REGEXP = /([a-zA-Z0-9]+[a-zA-Z0-9\-_\.]+)([><=\w\.,]+)?/
       REQUIREMENTS_REGEXP = /^#{REQUIRE_REGEXP}/
-      MANIFEST_REGEXP = /.*require[^\/]*(\/)?[^\/]*\.(txt|pip)$/
+      MANIFEST_REGEXP = /.*require[^\/]*(\/)?[^\/]*\.(txt|pip|in)$/
       PIP_COMPILE_REGEXP = /.*require.*$/
 
       def self.mapping

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "7.1.2"
+  VERSION = "7.1.3"
 end

--- a/spec/fixtures/pip-compile/requirements.in
+++ b/spec/fixtures/pip-compile/requirements.in
@@ -1,0 +1,10 @@
+invoke
+black
+google-cloud-storage
+six
+progress
+questionary
+pyyaml
+semver
+Jinja2
+pip-tools

--- a/spec/parsers/pypi_spec.rb
+++ b/spec/parsers/pypi_spec.rb
@@ -62,6 +62,26 @@ describe Bibliothecary::Parsers::Pypi do
     })
   end
 
+  it 'parses dependencies from requirements.in' do
+    expect(described_class.analyse_contents('requirements.in', load_fixture('pip-compile/requirements.in'))).to eq({
+      :platform=>"pypi",
+      :path=>"requirements.in",
+      :dependencies=>[
+        {:name=>"invoke", :requirement=>"*", :type=>"runtime"},
+        {:name=>"black", :requirement=>"*", :type=>"runtime"},
+        {:name=>"google-cloud-storage", :requirement=>"*", :type=>"runtime"},
+        {:name=>"six", :requirement=>"*", :type=>"runtime"},
+        {:name=>"progress", :requirement=>"*", :type=>"runtime"},
+        {:name=>"questionary", :requirement=>"*", :type=>"runtime"},
+        {:name=>"pyyaml", :requirement=>"*", :type=>"runtime"},
+        {:name=>"semver", :requirement=>"*", :type=>"runtime"},
+        {:name=>"Jinja2", :requirement=>"*", :type=>"runtime"},
+        {:name=>"pip-tools", :requirement=>"*", :type=>"runtime"}
+      ],
+      kind: 'manifest',
+      success: true
+    })
+  end
   it 'parses dependencies from requirements.txt as lockfile because of pip-compile' do
     expect(described_class.analyse_contents('requirements.txt', load_fixture('pip-compile/requirements.txt'))).to eq({
       :platform=>"pypi",


### PR DESCRIPTION
Thought I'd add in `.in` files too for `requirements.in` support as a manifest.