### PR TITLE
Add support for requirements.frozen being a lockfile

### DIFF
--- a/lib/bibliothecary/parsers/pypi.rb
+++ b/lib/bibliothecary/parsers/pypi.rb
@@ -26,6 +26,10 @@ module Bibliothecary
             parser: :parse_requirements_txt,
             can_have_lockfile: false
           },
+          match_filename('requirements.frozen') => { # pattern exists to store frozen deps in requirements.frozen
+            parser: :parse_requirements_txt,
+            kind: 'lockfile',
+          },
           match_filename('pip-resolved-dependencies.txt') => { # Inferred from pip
             kind: 'lockfile',
             parser: :parse_requirements_txt,

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "7.2.0"
+  VERSION = "7.2.1"
 end

--- a/spec/fixtures/requirements.frozen
+++ b/spec/fixtures/requirements.frozen
@@ -1,0 +1,3 @@
+asgiref==3.2.7
+Django==3.0.6
+sqlparse==0.3.1

--- a/spec/parsers/pypi_spec.rb
+++ b/spec/parsers/pypi_spec.rb
@@ -145,6 +145,20 @@ describe Bibliothecary::Parsers::Pypi do
     })
   end
 
+  it 'parses dependencies from requirements.frozen' do
+    expect(described_class.analyse_contents('requirements.frozen', load_fixture('requirements.frozen'))).to eq({
+      :platform=>"pypi",
+      :path=>"requirements.frozen",
+      :dependencies=>[
+        {:name=>"asgiref", :requirement=>"==3.2.7", :type=>"runtime"},
+        {:name=>"Django", :requirement=>"==3.0.6", :type=>"runtime"},
+        {:name=>"sqlparse", :requirement=>"==0.3.1", :type=>"runtime"}
+      ],
+      kind: 'lockfile',
+      success: true
+    })
+  end
+
   it 'parses dependencies from Pipfile' do
     expect(described_class.analyse_contents('Pipfile', load_fixture('Pipfile'))).to eq({
       :platform=>"pypi",


### PR DESCRIPTION
There's a pattern of running 'pip freeze > requirements.frozen'
which gets used by some places. This lets us nicely support it