### PR TITLE
Support a `dependencies.csv` file format that's just uninterpreted

### DIFF
--- a/lib/bibliothecary/parsers/generic.rb
+++ b/lib/bibliothecary/parsers/generic.rb
@@ -18,27 +18,21 @@ module Bibliothecary
         table = CSV.parse(file_contents, headers: true)
 
         required_headers = ["platform", "name", "requirement"]
-        missing_headers = []
-        for h in required_headers
-          missing_headers.push(h) unless table.headers.include?(h)
-        end
+        missing_headers = required_headers - table.headers
         raise "Missing headers #{missing_headers} in CSV" unless missing_headers.empty?
 
-        deps = []
-        line = 1
-        for row in table
-          for h in required_headers
+        table.map.with_index do |row, idx|
+          line = idx + 1
+          required_headers.each do |h|
             raise "missing field '#{h}' on line #{line}" if row[h].empty?
           end
-          line += 1
-          deps.push({
-                      platform: row['platform'],
-                      name: row['name'],
-                      requirement: row['requirement'],
-                      type: row.fetch('type', 'runtime'),
-                    })
+          {
+            platform: row['platform'],
+            name: row['name'],
+            requirement: row['requirement'],
+            type: row.fetch('type', 'runtime'),
+          }
         end
-        deps
       end
     end
   end

--- a/lib/bibliothecary/parsers/generic.rb
+++ b/lib/bibliothecary/parsers/generic.rb
@@ -1,0 +1,45 @@
+require 'csv'
+
+module Bibliothecary
+  module Parsers
+    class Generic
+      include Bibliothecary::Analyser
+
+      def self.mapping
+        {
+          match_filename("dependencies.csv") => {
+            kind: 'lockfile',
+            parser: :parse_lockfile
+          }
+        }
+      end
+
+      def self.parse_lockfile(file_contents)
+        table = CSV.parse(file_contents, headers: true)
+
+        required_headers = ["platform", "name", "requirement"]
+        missing_headers = []
+        for h in required_headers
+          missing_headers.push(h) unless table.headers.include?(h)
+        end
+        raise "Missing headers #{missing_headers} in CSV" unless missing_headers.empty?
+
+        deps = []
+        line = 1
+        for row in table
+          for h in required_headers
+            raise "missing field '#{h}' on line #{line}" if row[h].empty?
+          end
+          line += 1
+          deps.push({
+                      platform: row['platform'],
+                      name: row['name'],
+                      requirement: row['requirement'],
+                      type: row.fetch('type', 'runtime'),
+                    })
+        end
+        deps
+      end
+    end
+  end
+end

--- a/spec/bibliothecary_spec.rb
+++ b/spec/bibliothecary_spec.rb
@@ -17,6 +17,7 @@ describe Bibliothecary do
           Bibliothecary::Parsers::CRAN,
           Bibliothecary::Parsers::Dub,
           Bibliothecary::Parsers::Elm,
+          Bibliothecary::Parsers::Generic,
           Bibliothecary::Parsers::Go,
           Bibliothecary::Parsers::Hackage,
           Bibliothecary::Parsers::Haxelib,

--- a/spec/fixtures/dependencies.csv
+++ b/spec/fixtures/dependencies.csv
@@ -1,0 +1,3 @@
+platform,name,requirement,type
+maven,com.example:something,1.0.3,runtime
+maven,com.example:something-dev,1.0.4,development

--- a/spec/parsers/generic_spec.rb
+++ b/spec/parsers/generic_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Bibliothecary::Parsers::Generic do
+  it 'has a platform name' do
+    expect(described_class.platform_name).to eq('generic')
+  end
+
+  it 'parses dependencies from dependencies.csv' do
+    expect(described_class.analyse_contents('dependencies.csv', load_fixture('dependencies.csv'))).to eq({
+      :platform=>"maven",
+      :path=>"dependencies.csv",
+      :dependencies=>[
+        {:name=>"com.example:something", :requirement=>"1.0.3", :type=>"runtime"},
+        {:name=>"com.example:something-dev", :requirement=>"1.0.4", :type=>"development"}
+      ],
+      kind: 'lockfile',
+      success: true
+    })
+  end
+
+  it 'matches valid manifest filepaths' do
+    expect(described_class.match?('dependencies.csv')).to be_truthy
+  end
+end


### PR DESCRIPTION
This allows directly putting data into the canonical bibliothecary form.

In this commit, a `dependencies.csv` can only contain a single platform,
due to the need to refactor the bibliothecary API before we can return
multiple platforms from a single file.
