### PR TITLE
Handle gradle-dependencies-q.txt lines ending in " FAILED"

### DIFF
--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -127,10 +127,12 @@ module Bibliothecary
 
           split = gradle_dep_match.captures[0]
 
-          # org.springframework.boot:spring-boot-starter-web:2.1.0.M3 (*)
-          # Lines can end with (c), (n), or (*)
-          # to indicate that something was a dependency constraint (c), not resolved (n), or resolved previously (*).
-          dep = line.split(split)[1].sub(/(\((c|n|\*)\))$/, "").sub(" -> ", ":").strip.split(":")
+
+          dep = line
+            .split(split)[1].sub(/(\((c|n|\*)\))$/, "") # line ending legend: (c) means a dependency constraint, (n) means not resolved, or (*) means resolved previously, e.g. org.springframework.boot:spring-boot-starter-web:2.1.0.M3 (*)
+            .sub(/ FAILED$/, "") # dependency could not be resolved (but still may have a version)
+            .sub(" -> ", ":") # handle version arrow syntax
+            .strip.split(":")
 
           # A testImplementation line can look like this so just skip those
           # \--- org.springframework.security:spring-security-test (n)

--- a/spec/fixtures/gradle-dependencies-q.txt
+++ b/spec/fixtures/gradle-dependencies-q.txt
@@ -1399,6 +1399,8 @@ testCompileClasspath - Compile classpath for source set 'test'.
 +--- org.springframework:spring-test:5.1.0.RC3
 |    \--- org.springframework:spring-core:5.1.0.RC3 (*)
 +--- org.json:json:20160810
++--- org.projectlombok:lombok FAILED
++--- org.apiguardian:apiguardian-api:1.1.0 FAILED
 \--- project :api:cas-server-core-api-test-category
 
 testCompileOnly - Compile only dependencies for source set 'test'.

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -388,14 +388,26 @@ RSpec.describe Bibliothecary::Parsers::Maven do
       expect(test_runtime_classpath.length).to eq 187
       expect(test_runtime_classpath.select {|item| item[:name] == "org.glassfish.jaxb:jaxb-runtime"}.length).to eq 1
 
-      test_compile_classpath = deps[:dependencies].select {|item| item[:type] == "testRuntimeClasspath"}
+      test_compile_classpath = deps[:dependencies].select {|item| item[:type] == "testCompileClasspath"}
 
-      expect(test_compile_classpath.length).to eq 187
-      expect(test_runtime_classpath.select {|item| item[:name] == "org.slf4j:jul-to-slf4j"}.length).to eq 1
+      expect(test_compile_classpath.length).to eq 189
+      expect(test_compile_classpath.select {|item| item[:name] == "org.slf4j:jul-to-slf4j"}.length).to eq 1
     end
 
     it "excludes items in resolved deps file with no version" do
       expect(described_class.parse_gradle_resolved("\\--- org.springframework.security:spring-security-test (n)")).to eq []
+    end
+
+    it "excludes failed items with no version" do
+      expect(described_class.parse_gradle_resolved("+--- org.projectlombok:lombok FAILED")).to eq []
+    end
+
+    it "includes failed items with a version" do
+      expect(described_class.parse_gradle_resolved("+--- org.apiguardian:apiguardian-api:1.1.0 FAILED")).to eq [{
+        name: "org.apiguardian:apiguardian-api",
+        requirement: "1.1.0",
+        type: nil
+      }]
     end
 
     it "properly resolves versions with -> syntax" do


### PR DESCRIPTION
The first item here can't be parsed because there's no version, but the second version should be parsed as `1.1.0` instead of `1.1.0 FAILED`:

```
...
+--- org.projectlombok:lombok FAILED
\--- org.apiguardian:apiguardian-api:1.1.0 FAILED
...
```