### PR TITLE
Ensure npm-shrinkwrap takes precedence over other NPM lockfiles

### DIFF
--- a/lib/bibliothecary/parsers/npm.rb
+++ b/lib/bibliothecary/parsers/npm.rb
@@ -97,6 +97,18 @@ module Bibliothecary
         transform_tree_to_array(manifest.fetch('dependencies', {}))
       end
 
+      def self.lockfile_preference_order(file_infos)
+        files = file_infos.each_with_object({}) do |file_info, obj|
+          obj[File.basename(file_info.full_path)] = file_info
+        end
+
+        if files["npm-shrinkwrap.json"]
+          [files["npm-shrinkwrap.json"]] + files.values.reject { |fi| File.basename(fi.full_path) == "npm-shrinkwrap.json" }
+        else
+          files.values
+        end
+      end
+
       private_class_method def self.transform_tree_to_array(deps_by_name)
         deps_by_name.map do |name, metadata|
           [

--- a/lib/bibliothecary/related_files_info.rb
+++ b/lib/bibliothecary/related_files_info.rb
@@ -19,6 +19,9 @@ module Bibliothecary
 
     def initialize(file_infos)
       package_manager = file_infos.first.package_manager
+      if package_manager.respond_to?(:lockfile_preference_order)
+        file_infos = package_manager.lockfile_preference_order(file_infos)
+      end
       @platform = package_manager.platform_name
       @path = Pathname.new(File.dirname(file_infos.first.relative_path)).cleanpath.to_path
       # `package_manager.determine_kind_from_info(info)` can be an Array, so use include? which also works for string

--- a/spec/parsers/npm_spec.rb
+++ b/spec/parsers/npm_spec.rb
@@ -240,4 +240,22 @@ describe Bibliothecary::Parsers::NPM do
       success: true
     })
   end
+
+  describe ".lockfile_preference_order" do
+    let!(:shrinkwrap) { Bibliothecary::FileInfo.new(".", "npm-shrinkwrap.json") }
+    let!(:package_lock) { Bibliothecary::FileInfo.new(".", "package-lock.json") }
+    let!(:package) { Bibliothecary::FileInfo.new(".", "package.json") }
+
+    it 'prefers npm-shrinkwrap file infos first' do
+      expect(described_class.lockfile_preference_order([
+        package, package_lock, shrinkwrap
+      ])).to eq([ shrinkwrap, package, package_lock ])
+    end
+
+    it 'changes nothing if no shrinkwrap' do
+      expect(described_class.lockfile_preference_order([
+        package, package_lock
+      ])).to eq([ package, package_lock ])
+    end
+  end
 end


### PR DESCRIPTION
npm-shrinkwrap.json overrides other lockfiles when used with npm. Ensure that it's first, regardless of directory sort order.