### PR TITLE
Adds support for gradle-kotlin-dependencies-q.txt

### DIFF
--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -44,6 +44,10 @@ module Bibliothecary
             kind: 'manifest',
             parser: :parse_gradle
           },
+          match_filename("build.gradle.kts", case_insensitive: true) => {
+            kind: 'manifest',
+            parser: :parse_gradle_kts
+          },
           match_extension(".xml", case_insensitive: true) => {
             content_matcher: :ivy_report?,
             kind: 'lockfile',
@@ -55,7 +59,7 @@ module Bibliothecary
           },
           match_filename("gradle-kotlin-dependencies-q.txt", case_insensitive: true) => {
             kind: 'lockfile',
-            parser: :parse_gradle_resolved
+            parser: :parse_gradle_resolved # dependencies output should be same as build.gradle.
           },
           match_filename("maven-resolved-dependencies.txt", case_insensitive: true) => {
             kind: 'lockfile',
@@ -225,6 +229,12 @@ module Bibliothecary
             type: dependency["type"]
           }
         end.compact
+      end
+
+
+      def self.parse_gradle_kts(manifest)
+        # TODO: the gradle-parser side needs to be implemented for this, coming soon.
+        []
       end
 
       def self.gradle_dependency_name(group, name)

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -53,6 +53,10 @@ module Bibliothecary
             kind: 'lockfile',
             parser: :parse_gradle_resolved
           },
+          match_filename("gradle-kotlin-dependencies-q.txt", case_insensitive: true) => {
+            kind: 'lockfile',
+            parser: :parse_gradle_resolved
+          },
           match_filename("maven-resolved-dependencies.txt", case_insensitive: true) => {
             kind: 'lockfile',
             parser: :parse_maven_resolved

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "7.3.4"
+  VERSION = "7.3.5"
 end

--- a/spec/fixtures/gradle-kotlin-dependencies-q.txt
+++ b/spec/fixtures/gradle-kotlin-dependencies-q.txt
@@ -1,0 +1,312 @@
+
+------------------------------------------------------------
+Project ':app'
+------------------------------------------------------------
+
+annotationProcessor - Annotation processors and their dependencies for source set 'main'.
+No dependencies
+
+api - API dependencies for compilation 'main' (target  (jvm)). (n)
+No dependencies
+
+apiDependenciesMetadata
+No dependencies
+
+apiElements - API elements for main. (n)
+No dependencies
+
+apiElements-published (n)
+No dependencies
+
+archives - Configuration for archive artifacts. (n)
+No dependencies
+
+compileClasspath - Compile classpath for compilation 'main' (target  (jvm)).
++--- org.jetbrains.kotlin:kotlin-bom:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0 (c)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0
+|    |    +--- org.jetbrains:annotations:13.0
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+\--- com.google.guava:guava:30.1.1-jre
+     +--- com.google.guava:failureaccess:1.0.1
+     +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+     +--- com.google.code.findbugs:jsr305:3.0.2
+     +--- org.checkerframework:checker-qual:3.8.0
+     +--- com.google.errorprone:error_prone_annotations:2.5.1
+     \--- com.google.j2objc:j2objc-annotations:1.3
+
+compileOnly - Compile only dependencies for compilation 'main' (target  (jvm)).
+No dependencies
+
+compileOnlyDependenciesMetadata
+No dependencies
+
+default - Configuration for default artifacts. (n)
+No dependencies
+
+implementation - Implementation only dependencies for compilation 'main' (target  (jvm)). (n)
++--- org.jetbrains.kotlin:kotlin-bom:1.5.0 (n)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0 (n)
+\--- com.google.guava:guava:30.1.1-jre (n)
+
+implementationDependenciesMetadata
++--- org.jetbrains.kotlin:kotlin-bom:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0 (c)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0
+|    |    +--- org.jetbrains:annotations:13.0
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+\--- com.google.guava:guava:30.1.1-jre
+     +--- com.google.guava:failureaccess:1.0.1
+     +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+     +--- com.google.code.findbugs:jsr305:3.0.2
+     +--- org.checkerframework:checker-qual:3.8.0
+     +--- com.google.errorprone:error_prone_annotations:2.5.1
+     \--- com.google.j2objc:j2objc-annotations:1.3
+
+kotlinCompilerClasspath
+\--- org.jetbrains.kotlin:kotlin-compiler-embeddable:1.5.0
+     +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0
+     |    +--- org.jetbrains:annotations:13.0
+     |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0
+     +--- org.jetbrains.kotlin:kotlin-script-runtime:1.5.0
+     +--- org.jetbrains.kotlin:kotlin-reflect:1.5.0
+     |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+     +--- org.jetbrains.kotlin:kotlin-daemon-embeddable:1.5.0
+     \--- org.jetbrains.intellij.deps:trove4j:1.0.20181211
+
+kotlinCompilerPluginClasspath
+No dependencies
+
+kotlinCompilerPluginClasspathMain - Kotlin compiler plugins for compilation 'main' (target  (jvm))
+\--- org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.5.0
+     +--- org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable:1.5.0
+     |    +--- org.jetbrains.kotlin:kotlin-scripting-common:1.5.0
+     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0
+     |    |    |    +--- org.jetbrains:annotations:13.0
+     |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0
+     |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.8
+     |    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.5.0 (*)
+     |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.71 -> 1.5.0
+     |    +--- org.jetbrains.kotlin:kotlin-scripting-jvm:1.5.0
+     |    |    +--- org.jetbrains.kotlin:kotlin-script-runtime:1.5.0
+     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+     |    |    \--- org.jetbrains.kotlin:kotlin-scripting-common:1.5.0 (*)
+     |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+     |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.8 (*)
+     \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+
+kotlinCompilerPluginClasspathTest - Kotlin compiler plugins for compilation 'test' (target  (jvm))
+\--- org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.5.0
+     +--- org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable:1.5.0
+     |    +--- org.jetbrains.kotlin:kotlin-scripting-common:1.5.0
+     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0
+     |    |    |    +--- org.jetbrains:annotations:13.0
+     |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0
+     |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.8
+     |    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.5.0 (*)
+     |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.71 -> 1.5.0
+     |    +--- org.jetbrains.kotlin:kotlin-scripting-jvm:1.5.0
+     |    |    +--- org.jetbrains.kotlin:kotlin-script-runtime:1.5.0
+     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+     |    |    \--- org.jetbrains.kotlin:kotlin-scripting-common:1.5.0 (*)
+     |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+     |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.8 (*)
+     \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+
+kotlinKlibCommonizerClasspath
+\--- org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable:1.5.0
+     +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0
+     |    +--- org.jetbrains:annotations:13.0
+     |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0
+     \--- org.jetbrains.kotlin:kotlin-compiler-embeddable:1.5.0
+          +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+          +--- org.jetbrains.kotlin:kotlin-script-runtime:1.5.0
+          +--- org.jetbrains.kotlin:kotlin-reflect:1.5.0
+          |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+          +--- org.jetbrains.kotlin:kotlin-daemon-embeddable:1.5.0
+          \--- org.jetbrains.intellij.deps:trove4j:1.0.20181211
+
+kotlinNativeCompilerPluginClasspath
+No dependencies
+
+kotlinScriptDef - Script filename extensions discovery classpath configuration
+No dependencies
+
+kotlinScriptDefExtensions
+No dependencies
+
+runtimeClasspath - Runtime classpath of compilation 'main' (target  (jvm)).
++--- org.jetbrains.kotlin:kotlin-bom:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0 (c)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0
+|    |    +--- org.jetbrains:annotations:13.0
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+\--- com.google.guava:guava:30.1.1-jre
+     +--- com.google.guava:failureaccess:1.0.1
+     +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+     +--- com.google.code.findbugs:jsr305:3.0.2
+     +--- org.checkerframework:checker-qual:3.8.0
+     +--- com.google.errorprone:error_prone_annotations:2.5.1
+     \--- com.google.j2objc:j2objc-annotations:1.3
+
+runtimeElements - Elements of runtime for main. (n)
+No dependencies
+
+runtimeElements-published (n)
+No dependencies
+
+runtimeOnly - Runtime only dependencies for compilation 'main' (target  (jvm)). (n)
+No dependencies
+
+runtimeOnlyDependenciesMetadata
+No dependencies
+
+sourceArtifacts (n)
+No dependencies
+
+testAnnotationProcessor - Annotation processors and their dependencies for source set 'test'.
+No dependencies
+
+testApi - API dependencies for compilation 'test' (target  (jvm)). (n)
+No dependencies
+
+testApiDependenciesMetadata
+No dependencies
+
+testCompileClasspath - Compile classpath for compilation 'test' (target  (jvm)).
++--- org.jetbrains.kotlin:kotlin-bom:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-test:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-test-junit:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0 (c)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0
+|    |    +--- org.jetbrains:annotations:13.0
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
++--- com.google.guava:guava:30.1.1-jre
+|    +--- com.google.guava:failureaccess:1.0.1
+|    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+|    +--- com.google.code.findbugs:jsr305:3.0.2
+|    +--- org.checkerframework:checker-qual:3.8.0
+|    +--- com.google.errorprone:error_prone_annotations:2.5.1
+|    \--- com.google.j2objc:j2objc-annotations:1.3
++--- org.jetbrains.kotlin:kotlin-test:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+|    \--- org.jetbrains.kotlin:kotlin-test-junit:1.5.0
+|         +--- org.jetbrains.kotlin:kotlin-test:1.5.0 (*)
+|         \--- junit:junit:4.12
+|              \--- org.hamcrest:hamcrest-core:1.3
++--- org.jetbrains.kotlin:kotlin-test-junit:1.5.0 (*)
+\--- org.jetbrains.kotlin:kotlin-test:1.5.0 (*)
+
+testCompileOnly - Compile only dependencies for compilation 'test' (target  (jvm)).
+No dependencies
+
+testCompileOnlyDependenciesMetadata
+No dependencies
+
+testImplementation - Implementation only dependencies for compilation 'test' (target  (jvm)). (n)
++--- org.jetbrains.kotlin:kotlin-test:1.5.0 (n)
++--- org.jetbrains.kotlin:kotlin-test-junit:1.5.0 (n)
+\--- org.jetbrains.kotlin:kotlin-test:1.5.0 (n)
+
+testImplementationDependenciesMetadata
++--- org.jetbrains.kotlin:kotlin-bom:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-test:1.5.0 FAILED
+|    +--- org.jetbrains.kotlin:kotlin-test-junit:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-test-common:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-test-annotations-common:1.5.0 (c)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0
+|    |    +--- org.jetbrains:annotations:13.0
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
++--- com.google.guava:guava:30.1.1-jre
+|    +--- com.google.guava:failureaccess:1.0.1
+|    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+|    +--- com.google.code.findbugs:jsr305:3.0.2
+|    +--- org.checkerframework:checker-qual:3.8.0
+|    +--- com.google.errorprone:error_prone_annotations:2.5.1
+|    \--- com.google.j2objc:j2objc-annotations:1.3
++--- org.jetbrains.kotlin:kotlin-test:1.5.0 FAILED
++--- org.jetbrains.kotlin:kotlin-test-junit:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-test:1.5.0 FAILED
+|    \--- junit:junit:4.12
+|         \--- org.hamcrest:hamcrest-core:1.3
+\--- org.jetbrains.kotlin:kotlin-test:1.5.0 FAILED
+
+testKotlinScriptDef - Script filename extensions discovery classpath configuration
+No dependencies
+
+testKotlinScriptDefExtensions
+No dependencies
+
+testRuntimeClasspath - Runtime classpath of compilation 'test' (target  (jvm)).
++--- org.jetbrains.kotlin:kotlin-bom:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-test:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-test-junit:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0 (c)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0
+|    |    +--- org.jetbrains:annotations:13.0
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
++--- com.google.guava:guava:30.1.1-jre
+|    +--- com.google.guava:failureaccess:1.0.1
+|    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+|    +--- com.google.code.findbugs:jsr305:3.0.2
+|    +--- org.checkerframework:checker-qual:3.8.0
+|    +--- com.google.errorprone:error_prone_annotations:2.5.1
+|    \--- com.google.j2objc:j2objc-annotations:1.3
++--- org.jetbrains.kotlin:kotlin-test:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+|    \--- org.jetbrains.kotlin:kotlin-test-junit:1.5.0
+|         +--- org.jetbrains.kotlin:kotlin-test:1.5.0 (*)
+|         \--- junit:junit:4.12
+|              \--- org.hamcrest:hamcrest-core:1.3
++--- org.jetbrains.kotlin:kotlin-test-junit:1.5.0 (*)
+\--- org.jetbrains.kotlin:kotlin-test:1.5.0 (*)
+
+testRuntimeOnly - Runtime only dependencies for compilation 'test' (target  (jvm)). (n)
+No dependencies
+
+testRuntimeOnlyDependenciesMetadata
+No dependencies
+
+(c) - dependency constraint
+(*) - dependencies omitted (listed previously)
+
+(n) - Not resolved (configuration is not meant to be resolved)
+
+A web-based, searchable dependency report is available by adding the --scan option.

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -284,6 +284,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
     expect(described_class.match?('pom.xml')).to be_truthy
     expect(described_class.match?('ivy.xml')).to be_truthy
     expect(described_class.match?('build.gradle')).to be_truthy
+    expect(described_class.match?('build.gradle.kts')).to be_truthy
     # since the file doesn't really exist, we can't say it's a manifest file
     expect(described_class.match?('whatever.xml')).to be_falsey
     # but if it's a real file with contents we should be able to identify it has <ivy-report> in it

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -459,5 +459,13 @@ RSpec.describe Bibliothecary::Parsers::Maven do
       output = described_class.parse_maven_tree("[INFO] net.sourceforge.pmd:pmd-scala_2.12:jar:${someVariable}\n")
       expect(output).to eq [{:name=>"net.sourceforge.pmd:pmd-scala_2.12", :requirement=>"${someVariable}", :type=>"jar"}]
     end
+
+    it 'parses dependencies from gradle-kotlin-dependencies-q.txt' do
+      deps = described_class.analyse_contents('gradle-kotlin-dependencies-q.txt', load_fixture('gradle-kotlin-dependencies-q.txt'))
+      expect(deps[:kind]).to eq 'lockfile'
+      guavas = deps[:dependencies].select {|item| item[:name] == "com.google.guava:guava" && item[:type] == "testCompileClasspath"}
+      expect(guavas.length).to eq 1
+      expect(guavas[0][:requirement]).to eq '30.1.1-jre'
+    end
   end
 end


### PR DESCRIPTION
The new `gradle-kotlin-dependencies-q.txt` file will be the output of `gradle dependencies -q` on a `build.gradle.kts` file. 

It should be the same as the output from `build.gradle` AFAIK, but this uses a different name just in case there *are* differences, and also to denote that it came from a `build.gradle.kts` file.

(support for parsing `build.gradle.kts` is a bigger task and will come in a later PR)

