### PR TITLE
[7.3.5] Pre-support for build.gradle.kts

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ All available config options are in: https://github.com/librariesio/bibliothecar
   - pom.xml
   - ivy.xml
   - build.gradle
+  - gradle-dependencies-q.txt
 - RubyGems
   - Gemfile
   - Gemfile.lock

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -44,6 +44,10 @@ module Bibliothecary
             kind: 'manifest',
             parser: :parse_gradle
           },
+          match_filename("build.gradle.kts", case_insensitive: true) => {
+            kind: 'manifest',
+            parser: :parse_gradle_kts
+          },
           match_extension(".xml", case_insensitive: true) => {
             content_matcher: :ivy_report?,
             kind: 'lockfile',
@@ -221,6 +225,11 @@ module Bibliothecary
             type: dependency["type"]
           }
         end.compact
+      end
+
+      def self.parse_gradle_kts(manifest)
+        # TODO: the gradle-parser side needs to be implemented for this, coming soon.
+        []
       end
 
       def self.gradle_dependency_name(group, name)

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "7.3.4"
+  VERSION = "7.3.5"
 end

--- a/spec/fixtures/build.gradle.kts
+++ b/spec/fixtures/build.gradle.kts
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath("rootProject.ext.gradleClasspath")
+    }
+}
+
+apply(plugin = 'com.android.application')
+
+project.archivesBaseName = "muzei"
+
+repositories {
+    mavenCentral()
+}
+
+android {
+    compileSdkVersion(rootProject.ext.compileSdkVersion)
+    buildToolsVersion(rootProject.ext.buildToolsVersion)
+
+    defaultConfig {
+        minSdkVersion(17)
+        targetSdkVersion(rootProject.ext.targetSdkVersion)
+        renderscriptTargetApi(rootProject.ext.targetSdkVersion)
+        renderscriptSupportModeEnabled(true)
+
+        versionName = "1.0.0"
+        versionCode = 1
+    }
+
+    signingConfigs {
+        release {
+            storeFile(keyProps["store"] != null ? file(keyProps["store"]) : null)
+            keyAlias(keyProps["alias"] ?: "")
+            storePassword(keyProps["storePass"] ?: "")
+            keyPassword(keyProps["pass"] ?: "")
+        }
+    }
+
+    productFlavors {
+        dev {
+            // dev utilizes minSDKVersion = 21 to allow the Android gradle plugin
+            // to pre-dex each module and produce an APK that can be tested on
+            // Android Lollipop without time consuming dex merging processes.
+            minSdkVersion(21)
+            multiDexEnabled(true)
+        }
+
+        prod {
+        }
+    }
+
+    buildTypes {
+        debug {
+            versionNameSuffix(" Debug")
+        }
+
+        release {
+            minifyEnabled(true)
+            shrinkResources(true)
+            proguardFiles(getDefaultProguardFile('proguard-android.txt'), file('proguard-project.txt'))
+            signingConfig(signingConfigs.release)
+        }
+
+        publicBeta.initWith(buildTypes.release)
+        publicBeta {
+            minifyEnabled(true)
+            shrinkResources(true)
+            proguardFiles(getDefaultProguardFile('proguard-android.txt'), file('proguard-project.txt'))
+        }
+
+        publicDebug.initWith(buildTypes.publicBeta)
+        publicDebug {
+            debuggable(true)
+            renderscriptDebuggable(true)
+            minifyEnabled(true)
+            shrinkResources(true)
+            proguardFiles(getDefaultProguardFile('proguard-android.txt'), file('proguard-project.txt'))
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility(JavaVersion.VERSION_1_7)
+        targetCompatibility(JavaVersion.VERSION_1_7)
+    }
+}
+
+dependencies {
+    compile('com.squareup.okhttp:okhttp:2.1.0')
+    compile('com.squareup.okhttp:okhttp-urlconnection:2.1.0')
+    compile('com.squareup.picasso:picasso:2.4.0')
+    compile('com.google.android.gms:play-services-wearable:8.3.0')
+    compile('de.greenrobot:eventbus:2.4.0')
+    compile('com.android.support:appcompat-v7:23.1.1')
+    compile('com.android.support:recyclerview-v7:23.1.1')
+    compile('com.android.support:design:23.1.1')
+    compile('com.android.support:customtabs:23.1.1')
+    compile(files('android_libs/AdTechMobileSdk/ADTECHMobileSDK.jar'))
+
+    // :api is included as a transitive dependency from :android-client-common
+    // compile project(':api')
+    compile(project(':android-client-common'))
+    devWearApp(project(path: ':wearable', configuration: 'devRelease'))
+    prodWearApp(project(path: ':wearable', configuration: 'prodRelease'))
+}

--- a/spec/fixtures/gradle_with_kotlin/gradle-dependencies-q.txt
+++ b/spec/fixtures/gradle_with_kotlin/gradle-dependencies-q.txt
@@ -1,0 +1,312 @@
+
+------------------------------------------------------------
+Project ':app'
+------------------------------------------------------------
+
+annotationProcessor - Annotation processors and their dependencies for source set 'main'.
+No dependencies
+
+api - API dependencies for compilation 'main' (target  (jvm)). (n)
+No dependencies
+
+apiDependenciesMetadata
+No dependencies
+
+apiElements - API elements for main. (n)
+No dependencies
+
+apiElements-published (n)
+No dependencies
+
+archives - Configuration for archive artifacts. (n)
+No dependencies
+
+compileClasspath - Compile classpath for compilation 'main' (target  (jvm)).
++--- org.jetbrains.kotlin:kotlin-bom:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0 (c)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0
+|    |    +--- org.jetbrains:annotations:13.0
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+\--- com.google.guava:guava:30.1.1-jre
+     +--- com.google.guava:failureaccess:1.0.1
+     +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+     +--- com.google.code.findbugs:jsr305:3.0.2
+     +--- org.checkerframework:checker-qual:3.8.0
+     +--- com.google.errorprone:error_prone_annotations:2.5.1
+     \--- com.google.j2objc:j2objc-annotations:1.3
+
+compileOnly - Compile only dependencies for compilation 'main' (target  (jvm)).
+No dependencies
+
+compileOnlyDependenciesMetadata
+No dependencies
+
+default - Configuration for default artifacts. (n)
+No dependencies
+
+implementation - Implementation only dependencies for compilation 'main' (target  (jvm)). (n)
++--- org.jetbrains.kotlin:kotlin-bom:1.5.0 (n)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0 (n)
+\--- com.google.guava:guava:30.1.1-jre (n)
+
+implementationDependenciesMetadata
++--- org.jetbrains.kotlin:kotlin-bom:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0 (c)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0
+|    |    +--- org.jetbrains:annotations:13.0
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+\--- com.google.guava:guava:30.1.1-jre
+     +--- com.google.guava:failureaccess:1.0.1
+     +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+     +--- com.google.code.findbugs:jsr305:3.0.2
+     +--- org.checkerframework:checker-qual:3.8.0
+     +--- com.google.errorprone:error_prone_annotations:2.5.1
+     \--- com.google.j2objc:j2objc-annotations:1.3
+
+kotlinCompilerClasspath
+\--- org.jetbrains.kotlin:kotlin-compiler-embeddable:1.5.0
+     +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0
+     |    +--- org.jetbrains:annotations:13.0
+     |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0
+     +--- org.jetbrains.kotlin:kotlin-script-runtime:1.5.0
+     +--- org.jetbrains.kotlin:kotlin-reflect:1.5.0
+     |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+     +--- org.jetbrains.kotlin:kotlin-daemon-embeddable:1.5.0
+     \--- org.jetbrains.intellij.deps:trove4j:1.0.20181211
+
+kotlinCompilerPluginClasspath
+No dependencies
+
+kotlinCompilerPluginClasspathMain - Kotlin compiler plugins for compilation 'main' (target  (jvm))
+\--- org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.5.0
+     +--- org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable:1.5.0
+     |    +--- org.jetbrains.kotlin:kotlin-scripting-common:1.5.0
+     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0
+     |    |    |    +--- org.jetbrains:annotations:13.0
+     |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0
+     |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.8
+     |    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.5.0 (*)
+     |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.71 -> 1.5.0
+     |    +--- org.jetbrains.kotlin:kotlin-scripting-jvm:1.5.0
+     |    |    +--- org.jetbrains.kotlin:kotlin-script-runtime:1.5.0
+     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+     |    |    \--- org.jetbrains.kotlin:kotlin-scripting-common:1.5.0 (*)
+     |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+     |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.8 (*)
+     \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+
+kotlinCompilerPluginClasspathTest - Kotlin compiler plugins for compilation 'test' (target  (jvm))
+\--- org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.5.0
+     +--- org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable:1.5.0
+     |    +--- org.jetbrains.kotlin:kotlin-scripting-common:1.5.0
+     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0
+     |    |    |    +--- org.jetbrains:annotations:13.0
+     |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0
+     |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.8
+     |    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.71 -> 1.5.0 (*)
+     |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.71 -> 1.5.0
+     |    +--- org.jetbrains.kotlin:kotlin-scripting-jvm:1.5.0
+     |    |    +--- org.jetbrains.kotlin:kotlin-script-runtime:1.5.0
+     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+     |    |    \--- org.jetbrains.kotlin:kotlin-scripting-common:1.5.0 (*)
+     |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+     |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.8 (*)
+     \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+
+kotlinKlibCommonizerClasspath
+\--- org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable:1.5.0
+     +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0
+     |    +--- org.jetbrains:annotations:13.0
+     |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0
+     \--- org.jetbrains.kotlin:kotlin-compiler-embeddable:1.5.0
+          +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+          +--- org.jetbrains.kotlin:kotlin-script-runtime:1.5.0
+          +--- org.jetbrains.kotlin:kotlin-reflect:1.5.0
+          |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+          +--- org.jetbrains.kotlin:kotlin-daemon-embeddable:1.5.0
+          \--- org.jetbrains.intellij.deps:trove4j:1.0.20181211
+
+kotlinNativeCompilerPluginClasspath
+No dependencies
+
+kotlinScriptDef - Script filename extensions discovery classpath configuration
+No dependencies
+
+kotlinScriptDefExtensions
+No dependencies
+
+runtimeClasspath - Runtime classpath of compilation 'main' (target  (jvm)).
++--- org.jetbrains.kotlin:kotlin-bom:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0 (c)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0
+|    |    +--- org.jetbrains:annotations:13.0
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+\--- com.google.guava:guava:30.1.1-jre
+     +--- com.google.guava:failureaccess:1.0.1
+     +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+     +--- com.google.code.findbugs:jsr305:3.0.2
+     +--- org.checkerframework:checker-qual:3.8.0
+     +--- com.google.errorprone:error_prone_annotations:2.5.1
+     \--- com.google.j2objc:j2objc-annotations:1.3
+
+runtimeElements - Elements of runtime for main. (n)
+No dependencies
+
+runtimeElements-published (n)
+No dependencies
+
+runtimeOnly - Runtime only dependencies for compilation 'main' (target  (jvm)). (n)
+No dependencies
+
+runtimeOnlyDependenciesMetadata
+No dependencies
+
+sourceArtifacts (n)
+No dependencies
+
+testAnnotationProcessor - Annotation processors and their dependencies for source set 'test'.
+No dependencies
+
+testApi - API dependencies for compilation 'test' (target  (jvm)). (n)
+No dependencies
+
+testApiDependenciesMetadata
+No dependencies
+
+testCompileClasspath - Compile classpath for compilation 'test' (target  (jvm)).
++--- org.jetbrains.kotlin:kotlin-bom:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-test:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-test-junit:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0 (c)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0
+|    |    +--- org.jetbrains:annotations:13.0
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
++--- com.google.guava:guava:30.1.1-jre
+|    +--- com.google.guava:failureaccess:1.0.1
+|    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+|    +--- com.google.code.findbugs:jsr305:3.0.2
+|    +--- org.checkerframework:checker-qual:3.8.0
+|    +--- com.google.errorprone:error_prone_annotations:2.5.1
+|    \--- com.google.j2objc:j2objc-annotations:1.3
++--- org.jetbrains.kotlin:kotlin-test:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+|    \--- org.jetbrains.kotlin:kotlin-test-junit:1.5.0
+|         +--- org.jetbrains.kotlin:kotlin-test:1.5.0 (*)
+|         \--- junit:junit:4.12
+|              \--- org.hamcrest:hamcrest-core:1.3
++--- org.jetbrains.kotlin:kotlin-test-junit:1.5.0 (*)
+\--- org.jetbrains.kotlin:kotlin-test:1.5.0 (*)
+
+testCompileOnly - Compile only dependencies for compilation 'test' (target  (jvm)).
+No dependencies
+
+testCompileOnlyDependenciesMetadata
+No dependencies
+
+testImplementation - Implementation only dependencies for compilation 'test' (target  (jvm)). (n)
++--- org.jetbrains.kotlin:kotlin-test:1.5.0 (n)
++--- org.jetbrains.kotlin:kotlin-test-junit:1.5.0 (n)
+\--- org.jetbrains.kotlin:kotlin-test:1.5.0 (n)
+
+testImplementationDependenciesMetadata
++--- org.jetbrains.kotlin:kotlin-bom:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-test:1.5.0 FAILED
+|    +--- org.jetbrains.kotlin:kotlin-test-junit:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-test-common:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-test-annotations-common:1.5.0 (c)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0
+|    |    +--- org.jetbrains:annotations:13.0
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
++--- com.google.guava:guava:30.1.1-jre
+|    +--- com.google.guava:failureaccess:1.0.1
+|    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+|    +--- com.google.code.findbugs:jsr305:3.0.2
+|    +--- org.checkerframework:checker-qual:3.8.0
+|    +--- com.google.errorprone:error_prone_annotations:2.5.1
+|    \--- com.google.j2objc:j2objc-annotations:1.3
++--- org.jetbrains.kotlin:kotlin-test:1.5.0 FAILED
++--- org.jetbrains.kotlin:kotlin-test-junit:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-test:1.5.0 FAILED
+|    \--- junit:junit:4.12
+|         \--- org.hamcrest:hamcrest-core:1.3
+\--- org.jetbrains.kotlin:kotlin-test:1.5.0 FAILED
+
+testKotlinScriptDef - Script filename extensions discovery classpath configuration
+No dependencies
+
+testKotlinScriptDefExtensions
+No dependencies
+
+testRuntimeClasspath - Runtime classpath of compilation 'test' (target  (jvm)).
++--- org.jetbrains.kotlin:kotlin-bom:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-test:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-test-junit:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (c)
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0 (c)
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0 (c)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0
+|    |    +--- org.jetbrains:annotations:13.0
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.0
+|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
++--- com.google.guava:guava:30.1.1-jre
+|    +--- com.google.guava:failureaccess:1.0.1
+|    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+|    +--- com.google.code.findbugs:jsr305:3.0.2
+|    +--- org.checkerframework:checker-qual:3.8.0
+|    +--- com.google.errorprone:error_prone_annotations:2.5.1
+|    \--- com.google.j2objc:j2objc-annotations:1.3
++--- org.jetbrains.kotlin:kotlin-test:1.5.0
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.0 (*)
+|    \--- org.jetbrains.kotlin:kotlin-test-junit:1.5.0
+|         +--- org.jetbrains.kotlin:kotlin-test:1.5.0 (*)
+|         \--- junit:junit:4.12
+|              \--- org.hamcrest:hamcrest-core:1.3
++--- org.jetbrains.kotlin:kotlin-test-junit:1.5.0 (*)
+\--- org.jetbrains.kotlin:kotlin-test:1.5.0 (*)
+
+testRuntimeOnly - Runtime only dependencies for compilation 'test' (target  (jvm)). (n)
+No dependencies
+
+testRuntimeOnlyDependenciesMetadata
+No dependencies
+
+(c) - dependency constraint
+(*) - dependencies omitted (listed previously)
+
+(n) - Not resolved (configuration is not meant to be resolved)
+
+A web-based, searchable dependency report is available by adding the --scan option.

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -472,7 +472,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
     end
 
     it 'parses dependencies from gradle-dependencies-q.txt, generated from build.gradle.kts' do
-      # This should be the same but including it since the source file is in Groovy instead of Kotlin
+      # This output should be the same format as from build.gradle, but including it just to have a fixture from build.gradle.kts documented.
       deps = described_class.analyse_contents('gradle-dependencies-q.txt', load_fixture('gradle_with_kotlin/gradle-dependencies-q.txt'))
       expect(deps[:kind]).to eq 'lockfile'
       guavas = deps[:dependencies].select {|item| item[:name] == "com.google.guava:guava" && item[:type] == "testCompileClasspath"}


### PR DESCRIPTION
* accept `build.gradle.kts` but return empty list of deps (the parser work is ongoing)
* adds a spec fixture for a `gradle-dependencies-q.txt` file generated from a `build.gradle.kts`, just to document the output

(Re-do of https://github.com/librariesio/bibliothecary/pull/526/)