### PR TITLE
Fix error for missing fields in dependencies.csv parser

### DIFF
--- a/lib/bibliothecary/parsers/generic.rb
+++ b/lib/bibliothecary/parsers/generic.rb
@@ -22,7 +22,7 @@ module Bibliothecary
         raise "Missing headers #{missing_headers} in CSV" unless missing_headers.empty?
 
         table.map.with_index do |row, idx|
-          line = idx + 1
+          line = idx + 2 # use 1-based index just like the 'csv' std lib, and count the headers as first row.
           required_headers.each do |h|
             raise "missing field '#{h}' on line #{line}" if row[h].nil? || row[h].empty?
           end

--- a/lib/bibliothecary/parsers/generic.rb
+++ b/lib/bibliothecary/parsers/generic.rb
@@ -24,7 +24,7 @@ module Bibliothecary
         table.map.with_index do |row, idx|
           line = idx + 1
           required_headers.each do |h|
-            raise "missing field '#{h}' on line #{line}" if row[h].empty?
+            raise "missing field '#{h}' on line #{line}" if row[h].nil? || row[h].empty?
           end
           {
             platform: row['platform'],

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "7.3.5"
+  VERSION = "7.3.6"
 end

--- a/spec/parsers/generic_spec.rb
+++ b/spec/parsers/generic_spec.rb
@@ -21,4 +21,10 @@ describe Bibliothecary::Parsers::Generic do
   it 'matches valid manifest filepaths' do
     expect(described_class.match?('dependencies.csv')).to be_truthy
   end
+
+  it 'raises an error for blank required fields' do
+    csv = %Q!platform,name,requirement\ngo,something,!
+    result = described_class.analyse_contents('dependencies.csv', csv)
+    expect(result[:error_message]).to eq("dependencies.csv: missing field 'requirement' on line 1")
+  end
 end

--- a/spec/parsers/generic_spec.rb
+++ b/spec/parsers/generic_spec.rb
@@ -25,6 +25,6 @@ describe Bibliothecary::Parsers::Generic do
   it 'raises an error for blank required fields' do
     csv = %Q!platform,name,requirement\ngo,something,!
     result = described_class.analyse_contents('dependencies.csv', csv)
-    expect(result[:error_message]).to eq("dependencies.csv: missing field 'requirement' on line 1")
+    expect(result[:error_message]).to eq("dependencies.csv: missing field 'requirement' on line 2")
   end
 end


### PR DESCRIPTION
When a dependencies.csv has a blank field, we were check for emptiness without checking for nilness first:

### Before

```{:dependencies=>nil, :error_message=>"dependencies.csv: undefined method `empty?' for nil:NilClass", :kind=>"lockfile", :path=>"dependencies.csv", :platform=>"generic", :success=>false}```

### After

```{:dependencies=>nil, :error_message=>"dependencies.csv: missing field 'requirement' on line 1", :kind=>"lockfile", :path=>"dependencies.csv", :platform=>"generic", :success=>false}```