### PR TITLE
[8.2.1] Expand simple parsing support for build.gradle.kts

### DIFF
--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -250,7 +250,7 @@ module Bibliothecary
       def self.parse_gradle_kts(file_contents, options: {})
         file_contents
           .scan(GRADLE_KTS_SIMPLE_REGEX)                                                  # match 'implementation("group:artifactId:version")'
-          .reject { |(_type, group, artifactId, version)| group.nil? || artifactId.nil? } # remove any matches with missing group/artifactId
+          .reject { |(_type, group, artifactId, _version)| group.nil? || artifactId.nil? } # remove any matches with missing group/artifactId
           .map { |(type, group, artifactId, version)|
             {
               name: [group, artifactId].join(":"),

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -18,10 +18,11 @@ module Bibliothecary
       # An intentionally overly-simplified regex to scrape deps from build.gradle.kts files. 
       # To be truly useful bibliothecary would need a full Kotlin parser that speaks Gradle, 
       # because the Kotlin DSL has many dynamic ways of declaring dependencies.
-      GRADLE_KTS_SIMPLE_REGEX = /(#{GRADLE_KTS_DEPENDENCY_METHODS.join('|')})\s*\(\s*"([^"]+)"\s*\)/m
       
-      # e.g. "group:artifactId:1.2.3"
-      GRADLE_KTS_GAV_REGEX = /([\w.-]+)\:([\w.-]+)(?:\:([\w.-]+))?/
+      GRADLE_KTS_VERSION_REGEX = /[\w.-]+/ # e.g. '1.2.3'
+      GRADLE_KTS_INTERPOLATED_VERSION_REGEX = /\$\{.*\}/ # e.g. '${my-project-settings["version"]}'
+      GRADLE_KTS_GAV_REGEX = /([\w.-]+)\:([\w.-]+)(?:\:(#{GRADLE_KTS_VERSION_REGEX}|#{GRADLE_KTS_INTERPOLATED_VERSION_REGEX}))?/
+      GRADLE_KTS_SIMPLE_REGEX = /(#{GRADLE_KTS_DEPENDENCY_METHODS.join('|')})\s*\(\s*"#{GRADLE_KTS_GAV_REGEX}"\s*\)\s*$/m # e.g. "group:artifactId:1.2.3"
 
       MAVEN_PROPERTY_REGEX = /\$\{(.+?)\}/
       MAX_DEPTH = 5
@@ -248,14 +249,13 @@ module Bibliothecary
 
       def self.parse_gradle_kts(file_contents, options: {})
         file_contents
-          .scan(GRADLE_KTS_SIMPLE_REGEX)                                                   # match 'implementation("group:artifactId:version")'
-          .map { |(_type, dep_match)| GRADLE_KTS_GAV_REGEX.match(dep_match) }              # extract ["group", "artifactId", ?"version"]
-          .reject { |gav_match| gav_match.nil? || gav_match[1].nil? || gav_match[2].nil? } # remove any with missing group/artifactId
-          .map { |gav_match|
+          .scan(GRADLE_KTS_SIMPLE_REGEX)                                                  # match 'implementation("group:artifactId:version")'
+          .reject { |(_type, group, artifactId, version)| group.nil? || artifactId.nil? } # remove any matches with missing group/artifactId
+          .map { |(type, group, artifactId, version)|
             {
-              name: [gav_match[1], gav_match[2]].join(":"),
-              requirement: gav_match[3] || "*",
-              type: nil # TODO: we may be able to infer dep types using the _type var above.
+              name: [group, artifactId].join(":"),
+              requirement: version || "*",
+              type: type
             }
           }
       end

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.2.2"
+  VERSION = "8.2.1"
 end

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.2.0"
+  VERSION = "8.2.1"
 end

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.2.1"
+  VERSION = "8.2.2"
 end

--- a/spec/fixtures/build.gradle.kts
+++ b/spec/fixtures/build.gradle.kts
@@ -34,6 +34,11 @@ dependencies {
 
     // Use the Kotlin JUnit integration.
     testImplementation(     "org.jetbrains.kotlin:kotlin-test-junit:1.0.0"     )
+
+    implementation(project(":my-internal-lib"))
+
+    // --- Androidx ---
+    implementation("androidx.annotation:annotation:${rootProject.extra["androidx_annotation_version"]}")
 }
 
 application {

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -212,15 +212,16 @@ RSpec.describe Bibliothecary::Parsers::Maven do
       })
     end
 
-    it 'parses dependencies from build.gradle', :vcr do
+    it 'parses dependencies from build.gradle.kts' do
       expect(described_class.analyse_contents('build.gradle.kts', load_fixture('build.gradle.kts'))).to eq({
         :platform=>"maven",
         :path=>"build.gradle.kts",
         :dependencies=>[
-          {name: "org.jetbrains.kotlin:kotlin-stdlib-jdk8", requirement: "*", type: nil},
-          {name: "com.google.guava:guava", requirement: "30.1.1-jre", type: nil},
-          {name: "org.jetbrains.kotlin:kotlin-test", requirement: "*", type: nil},
-          {name: "org.jetbrains.kotlin:kotlin-test-junit", requirement: "1.0.0", type: nil}
+          {name: "org.jetbrains.kotlin:kotlin-stdlib-jdk8", requirement: "*", type: "implementation"},
+          {name: "com.google.guava:guava", requirement: "30.1.1-jre", type: "implementation"},
+          {name: "org.jetbrains.kotlin:kotlin-test", requirement: "*", type: "testImplementation"},
+          {name: "org.jetbrains.kotlin:kotlin-test-junit", requirement: "1.0.0", type: "testImplementation"},
+          {name: "androidx.annotation:annotation", requirement: "${rootProject.extra[\"androidx_annotation_version\"]}", type: "implementation"}
         ],
         kind: 'manifest',
         success: true


### PR DESCRIPTION
* refactor the `build.gradle.kts` parsing regexes 
* add support for interpolated verisons, e.g. `group:artifactId:${someVar["my-version"]}`
* and start returning the method used for the dep in`type` , e.g. "implementation". This is what the `build.gradle` parser currently does as well

Folllowup to https://github.com/librariesio/bibliothecary/pull/532