### PR TITLE
Gracefully handle pypoetry.toml files with no dependencies.

### DIFF
--- a/lib/bibliothecary/parsers/pypi.rb
+++ b/lib/bibliothecary/parsers/pypi.rb
@@ -84,7 +84,7 @@ module Bibliothecary
       end
 
       def self.parse_poetry(file_contents, options: {})
-        manifest = Tomlrb.parse(file_contents)['tool']['poetry']
+        manifest = Tomlrb.parse(file_contents).fetch('tool', {}).fetch('poetry', {})
         map_dependencies(manifest['dependencies'], 'runtime') + map_dependencies(manifest['dev-dependencies'], 'develop')
       end
 

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.2.5"
+  VERSION = "8.2.6"
 end

--- a/spec/parsers/pypi_spec.rb
+++ b/spec/parsers/pypi_spec.rb
@@ -272,6 +272,21 @@ git://what@::/:/:/
     })
   end
 
+  it 'handles pyproject.toml with no deps' do
+    source = <<~FILE
+      [tool.black]
+      line-length = 100
+    FILE
+
+    expect(described_class.analyse_contents('pyproject.toml', source)).to eq({
+      :platform=>"pypi",
+      :path=>"pyproject.toml",
+      :dependencies=>[],
+      kind: 'manifest',
+      success: true
+    })
+  end
+
   it 'parses dependencies from Poetry.lock' do
     expect(described_class.analyse_contents('poetry.lock', load_fixture('poetry.lock'))).to eq({
       :platform=>"pypi",


### PR DESCRIPTION
Sometimes these files are just non-dependency related configuration.