### PR TITLE
Support more gradle syntax variations.

### DIFF
--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -23,9 +23,8 @@ module Bibliothecary
       GRADLE_VAR_INTERPOLATION_REGEX = /\$\w+/ # e.g. '$myVersion'
       GRADLE_CODE_INTERPOLATION_REGEX = /\$\{.*\}/ # e.g. '${my-project-settings["version"]}'
       GRADLE_GAV_REGEX = /([\w.-]+)\:([\w.-]+)(?:\:(#{GRADLE_VERSION_REGEX}|#{GRADLE_VAR_INTERPOLATION_REGEX}|#{GRADLE_CODE_INTERPOLATION_REGEX}))?/ # e.g. "group:artifactId:1.2.3"
-      GRADLE_COMMENT_REGEX = /\/\/.*|\/\*.*\*\// # '// hello' or '/* hello */'
-      GRADLE_GROOVY_SIMPLE_REGEX = /(#{GRADLE_DEPENDENCY_METHODS.join('|')})\s*\(?\s*['"]#{GRADLE_GAV_REGEX}['"]\s*\)?\s*(?:#{GRADLE_COMMENT_REGEX})*$/m 
-      GRADLE_KOTLIN_SIMPLE_REGEX = /(#{GRADLE_DEPENDENCY_METHODS.join('|')})\s*\(\s*"#{GRADLE_GAV_REGEX}"\s*\)\s*(?:#{GRADLE_COMMENT_REGEX})*$/m 
+      GRADLE_GROOVY_SIMPLE_REGEX = /(#{GRADLE_DEPENDENCY_METHODS.join('|')})\s*\(?\s*['"]#{GRADLE_GAV_REGEX}['"]/m 
+      GRADLE_KOTLIN_SIMPLE_REGEX = /(#{GRADLE_DEPENDENCY_METHODS.join('|')})\s*\(\s*"#{GRADLE_GAV_REGEX}"/m 
 
       MAVEN_PROPERTY_REGEX = /\$\{(.+?)\}/
       MAX_DEPTH = 5

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -24,7 +24,7 @@ module Bibliothecary
       GRADLE_CODE_INTERPOLATION_REGEX = /\$\{.*\}/ # e.g. '${my-project-settings["version"]}'
       GRADLE_GAV_REGEX = /([\w.-]+)\:([\w.-]+)(?:\:(#{GRADLE_VERSION_REGEX}|#{GRADLE_VAR_INTERPOLATION_REGEX}|#{GRADLE_CODE_INTERPOLATION_REGEX}))?/ # e.g. "group:artifactId:1.2.3"
       GRADLE_COMMENT_REGEX = /\/\/.*|\/\*.*\*\// # '// hello' or '/* hello */'
-      GRADLE_GROOVY_SIMPLE_REGEX = /(#{GRADLE_DEPENDENCY_METHODS.join('|')})\s+['"]#{GRADLE_GAV_REGEX}['"]\s*(?:#{GRADLE_COMMENT_REGEX})*$/m 
+      GRADLE_GROOVY_SIMPLE_REGEX = /(#{GRADLE_DEPENDENCY_METHODS.join('|')})\s*\(?\s*['"]#{GRADLE_GAV_REGEX}['"]\s*\)?\s*(?:#{GRADLE_COMMENT_REGEX})*$/m 
       GRADLE_KOTLIN_SIMPLE_REGEX = /(#{GRADLE_DEPENDENCY_METHODS.join('|')})\s*\(\s*"#{GRADLE_GAV_REGEX}"\s*\)\s*(?:#{GRADLE_COMMENT_REGEX})*$/m 
 
       MAVEN_PROPERTY_REGEX = /\$\{(.+?)\}/

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.3.0"
+  VERSION = "8.3.1"
 end

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -182,6 +182,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
           compileOnly "this.thing:neat" // I am a comment
           testCompile "hello.there:im.a.dep:$versionThing" // I am a comment
           compile('this.has:parens')
+          compile 'junit:junit:4.13.2', { force = true }
         }
       FILE
 
@@ -192,6 +193,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
         {:name=>"this.thing:neat", :requirement=>"*", :type=>"compileOnly"},
         {:name=>"hello.there:im.a.dep", :requirement=>"$versionThing", :type=>"testCompile"},
         {:name=>"this.has:parens", :requirement=>"*", :type=>"compile"},
+        {:name=>"junit:junit", :requirement=>"4.13.2", :type=>"compile"},
       ])
     end
 

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
   end
 
   context 'gradle' do
-    it 'cleans up incorrectly parsed dependencies' do
+    it 'parses various dependency syntax variations' do
       source = <<~FILE
         dependencies {
           compile 'com.whatever:liblib:1.2.3'
@@ -181,6 +181,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
           compile "com.fasterxml.jackson.core:jackson-databind"
           compileOnly "this.thing:neat" // I am a comment
           testCompile "hello.there:im.a.dep:$versionThing" // I am a comment
+          compile('this.has:parens')
         }
       FILE
 
@@ -190,6 +191,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
         {:name=>"com.fasterxml.jackson.core:jackson-databind", :requirement=>"*", :type=>"compile"},
         {:name=>"this.thing:neat", :requirement=>"*", :type=>"compileOnly"},
         {:name=>"hello.there:im.a.dep", :requirement=>"$versionThing", :type=>"testCompile"},
+        {:name=>"this.has:parens", :requirement=>"*", :type=>"compile"},
       ])
     end
 


### PR DESCRIPTION
* simplify the Groovy/Kotlin regexes: we don't need to parse the comments/closures/etc at the end of the lines
* this means we'll start picking up deps that open a closure on the same line, e.g. `implementation "foo:bar:1.2.3", { ...`
* also support Groovy deps that are wrapped in parens (like Kotlin), e.g. `implementation("foo:bar:1.2.3")`