### PR TITLE
handle gradle deps which resolve with a rename

### DIFF
--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -159,9 +159,17 @@ module Bibliothecary
           # \--- org.springframework.security:spring-security-test (n)
           next unless dep.length >= 3
 
+          dep_name = if dep.count == 6
+                       # get name from renamed package resolution "org:name:version -> renamed_org:name:version"
+                       dep[-3..-2]
+                     else
+                       # get name from version conflict resolution ("org:name:version -> version") and no-resolution ("org:name:version")
+                       dep[0..1]
+                     end
+
           version = dep[-1]
           {
-            name: dep[0..1].join(":"),
+            name: dep_name.join(":"),
             requirement: version,
             type: type
           }

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.3.2"
+  VERSION = "8.3.3"
 end

--- a/spec/fixtures/gradle-dependencies-q.txt
+++ b/spec/fixtures/gradle-dependencies-q.txt
@@ -904,7 +904,7 @@ runtimeClasspath - Runtime classpath of source set 'main'.
 |    \--- commons-logging:commons-logging:1.2
 +--- org.apache.httpcomponents:httpcore:4.4.10
 +--- com.github.axet:wget:1.4.9
-|    +--- commons-io:commons-io:2.5 -> 2.6
+|    +--- apache:commons-io:1.4 -> commons-io:commons-io:2.6
 |    +--- com.github.axet:threads:0.0.14
 |    \--- org.jsoup:jsoup:1.10.1
 +--- org.quartz-scheduler:quartz:2.3.0

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -434,6 +434,10 @@ RSpec.describe Bibliothecary::Parsers::Maven do
       expect(test_runtime_classpath.length).to eq 187
       expect(test_runtime_classpath.select {|item| item[:name] == "org.glassfish.jaxb:jaxb-runtime"}.length).to eq 1
 
+      # test rename resolution
+      expect(test_runtime_classpath.select {|item| item[:name] == "commons-io:commons-io"}.length).to eq 1
+      expect(test_runtime_classpath.select {|item| item[:name] == "apache:commons-io"}).to eq []
+
       test_compile_classpath = deps[:dependencies].select {|item| item[:type] == "testCompileClasspath"}
 
       expect(test_compile_classpath.length).to eq 189


### PR DESCRIPTION
Dependencies which resolve with a package rename are using the pre-rename name for a dependency

ThIs change resolves to the new name, instead of pre-rename