### PR TITLE
Look for custom "Scope" value in go-resolved-dependencies.json

### DIFF
--- a/lib/bibliothecary/parsers/go.rb
+++ b/lib/bibliothecary/parsers/go.rb
@@ -150,7 +150,7 @@ module Bibliothecary
       def self.parse_go_resolved(file_contents, options: {})
         JSON.parse(file_contents)
           .select { |dep| dep["Main"] != "true" }
-          .map { |dep| { name: dep["Path"], requirement: dep["Version"], type: 'runtime' } }
+          .map { |dep| { name: dep["Path"], requirement: dep["Version"], type: dep.fetch("Scope") { "runtime" } } }
       end
 
       def self.map_dependencies(manifest, attr_name, dep_attr_name, version_attr_name, type)

--- a/spec/fixtures/go-resolved-dependencies.json
+++ b/spec/fixtures/go-resolved-dependencies.json
@@ -2,84 +2,105 @@
       "Path": "main",
       "Main": "true",
       "Version": "",
-      "Indirect": "false"
+      "Indirect": "false",
+      "Scope": "runtime"
     },
     {
       "Path": "cloud.google.com/go",
       "Main": "false",
       "Version": "v0.36.0",
-      "Indirect": "true"
+      "Indirect": "true",
+      "Scope": "runtime"
     },
     {
       "Path": "dmitri.shuralyov.com/app/changes",
       "Main": "false",
       "Version": "v0.0.0-20180602232624-0a106ad413e3",
-      "Indirect": "true"
+      "Indirect": "true",
+      "Scope": "runtime"
     },
     {
       "Path": "dmitri.shuralyov.com/html/belt",
       "Main": "false",
       "Version": "v0.0.0-20180602232347-f7d459c86be0",
-      "Indirect": "true"
+      "Indirect": "true",
+      "Scope": "runtime"
     },
     {
       "Path": "dmitri.shuralyov.com/service/change",
       "Main": "false",
       "Version": "v0.0.0-20181023043359-a85b471d5412",
-      "Indirect": "true"
+      "Indirect": "true",
+      "Scope": "runtime"
     },
     {
       "Path": "dmitri.shuralyov.com/state",
       "Main": "false",
       "Version": "v0.0.0-20180228185332-28bcc343414c",
-      "Indirect": "true"
+      "Indirect": "true",
+      "Scope": "runtime"
     },
     {
       "Path": "git.apache.org/thrift.git",
       "Main": "false",
       "Version": "v0.0.0-20180902110319-2566ecd5d999",
-      "Indirect": "true"
+      "Indirect": "true",
+      "Scope": "runtime"
     },
     {
       "Path": "github.com/BurntSushi/toml",
       "Main": "false",
       "Version": "v0.3.1",
-      "Indirect": "true"
+      "Indirect": "true",
+      "Scope": "runtime"
     },
     {
       "Path": "github.com/Masterminds/semver",
       "Main": "false",
       "Version": "v1.5.0",
-      "Indirect": "true"
+      "Indirect": "true",
+      "Scope": "runtime"
     },
     {
       "Path": "github.com/Masterminds/semver/v3",
       "Main": "false",
       "Version": "v3.0.3",
-      "Indirect": "true"
+      "Indirect": "true",
+      "Scope": "runtime"
     },
     {
       "Path": "github.com/OneOfOne/xxhash",
       "Main": "false",
       "Version": "v1.2.2",
-      "Indirect": "true"
+      "Indirect": "true",
+      "Scope": "runtime"
     },
     {
       "Path": "github.com/ajg/form",
       "Main": "false",
       "Version": "v1.5.1",
-      "Indirect": "true"
+      "Indirect": "true",
+      "Scope": "runtime"
     },
     {
       "Path": "github.com/alecthomas/template",
       "Main": "false",
       "Version": "v0.0.0-20160405071501-a0175ee3bccc",
-      "Indirect": "true"
+      "Indirect": "true",
+      "Scope": "runtime"
     },
     {
       "Path": "github.com/alecthomas/units",
       "Main": "false",
       "Version": "v0.0.0-20151022065526-2efee857e7cf",
-      "Indirect": "true"
+      "Indirect": "true",
+      "Scope": "runtime"
+    },
+    {
+      "Path": "github.com/stretchr/testify",
+      "Main": "false",
+      "Version": "v1.7.0",
+      "Indirect": "false",
+      "Scope": "test"
     }
   ]

--- a/spec/parsers/go_spec.rb
+++ b/spec/parsers/go_spec.rb
@@ -282,6 +282,7 @@ describe Bibliothecary::Parsers::Go do
         {:name=>"github.com/ajg/form", :requirement=>"v1.5.1", :type=>"runtime"},
         {:name=>"github.com/alecthomas/template", :requirement=>"v0.0.0-20160405071501-a0175ee3bccc", :type=>"runtime"},
         {:name=>"github.com/alecthomas/units", :requirement=>"v0.0.0-20151022065526-2efee857e7cf", :type=>"runtime"},
+        {:name=>"github.com/stretchr/testify", :requirement=>"v1.7.0", :type=>"test"},
       ],
       kind: 'lockfile',
       success: true


### PR DESCRIPTION
There's a new "Scope" field returned in this file with a value of `runtime` or `test`, so we can return that for the "type" field now.