### PR TITLE
Capture original_{name,requirement} in maven parser, for gradle aliases.

### DIFF
--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.3.4"
+  VERSION = "8.3.5"
 end

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -425,6 +425,16 @@ RSpec.describe Bibliothecary::Parsers::Maven do
       expect(runtime_classpath.length).to eq 156
       expect(runtime_classpath.select {|item| item[:name] == "com.google.guava:guava"}.length).to eq 1
 
+      # test rename resolution
+      renamed_dep = runtime_classpath.
+        select do |item| 
+          item[:name] == "commons-io:commons-io" && 
+          item[:original_name] == "apache:commons-io" &&
+          item[:requirement] == "2.6" &&
+          item[:original_requirement] == "1.4" 
+        end
+      expect(renamed_dep.length).to eq 1
+
       test_runtime_only = deps[:dependencies].select {|item| item[:type] == "testRuntimeOnly"}
 
       expect(test_runtime_only.length).to eq 0
@@ -434,9 +444,6 @@ RSpec.describe Bibliothecary::Parsers::Maven do
       expect(test_runtime_classpath.length).to eq 187
       expect(test_runtime_classpath.select {|item| item[:name] == "org.glassfish.jaxb:jaxb-runtime"}.length).to eq 1
 
-      # test rename resolution
-      expect(test_runtime_classpath.select {|item| item[:name] == "commons-io:commons-io"}.length).to eq 1
-      expect(test_runtime_classpath.select {|item| item[:name] == "apache:commons-io"}).to eq []
 
       test_compile_classpath = deps[:dependencies].select {|item| item[:type] == "testCompileClasspath"}
 


### PR DESCRIPTION
When we see an alias in `gradle-dependencies-q.txt`, capture `:original_name` and `:original_requirement`. For example:

`|    +--- apache:commons-io:1.4 -> commons-io:commons-io:2.6`

``` ruby
{
  original_name: "apache:commons-io",
  original_requirement: "1.4",
  name: "commons-io:commons-io",
  requirement: "2.6",
  type: "runtimeClassPath",  
}
```

NB Bibliothecary already uses the `:original_name` key for transforming Packagist/Drupal package names.