### PR TITLE
Handle shrinkwrap files the same as package-lock

### DIFF
--- a/lib/bibliothecary/parsers/npm.rb
+++ b/lib/bibliothecary/parsers/npm.rb
@@ -36,20 +36,14 @@ module Bibliothecary
       add_multi_parser(Bibliothecary::MultiParsers::CycloneDX)
       add_multi_parser(Bibliothecary::MultiParsers::DependenciesCSV)
 
-      def self.parse_shrinkwrap(file_contents, options: {})
-        manifest = JSON.parse(file_contents)
-        manifest.fetch('dependencies',[]).map do |name, requirement|
-          {
-            name: name,
-            requirement: requirement["version"],
-            type: 'runtime'
-          }
-        end
-      end
-
       def self.parse_package_lock(file_contents, options: {})
         manifest = JSON.parse(file_contents)
         parse_package_lock_deps_recursively(manifest.fetch('dependencies', []))
+      end
+
+      class << self
+        # "package-lock.json" and "npm-shrinkwrap.json" have same format, so use same parsing logic
+        alias_method :parse_shrinkwrap, :parse_package_lock
       end
 
       def self.parse_package_lock_deps_recursively(dependencies, depth=1)

--- a/spec/fixtures/npm-shrinkwrap.json
+++ b/spec/fixtures/npm-shrinkwrap.json
@@ -864,6 +864,7 @@
       "version": "2.2.0",
       "from": "debug@>=2.1.3 <3.0.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "dev": true,
       "dependencies": {
         "ms": {
           "version": "0.7.1",

--- a/spec/parsers/npm_spec.rb
+++ b/spec/parsers/npm_spec.rb
@@ -62,32 +62,32 @@ describe Bibliothecary::Parsers::NPM do
   end
 
   it 'parses dependencies from npm-shrinkwrap.json' do
-    expect(described_class.analyse_contents('npm-shrinkwrap.json', load_fixture('npm-shrinkwrap.json'))).to eq({
-      :platform=>"npm",
-      :path=>"npm-shrinkwrap.json",
-      :dependencies=>[
-        {:name=>"babel", :requirement=>"4.7.16", :type=>"runtime"},
-        {:name=>"body-parser", :requirement=>"1.13.3", :type=>"runtime"},
-        {:name=>"bugsnag", :requirement=>"1.6.5", :type=>"runtime"},
-        {:name=>"cookie-session", :requirement=>"1.2.0", :type=>"runtime"},
-        {:name=>"debug", :requirement=>"2.2.0", :type=>"runtime"},
-        {:name=>"deep-diff", :requirement=>"0.3.2", :type=>"runtime"},
-        {:name=>"deep-equal", :requirement=>"1.0.0", :type=>"runtime"},
-        {:name=>"express", :requirement=>"4.13.3", :type=>"runtime"},
-        {:name=>"express-session", :requirement=>"1.11.3", :type=>"runtime"},
-        {:name=>"jade", :requirement=>"1.11.0", :type=>"runtime"},
-        {:name=>"js-yaml", :requirement=>"3.4.0", :type=>"runtime"},
-        {:name=>"memwatch-next", :requirement=>"0.2.9", :type=>"runtime"},
-        {:name=>"multer", :requirement=>"0.1.8", :type=>"runtime"},
-        {:name=>"qs", :requirement=>"2.4.2", :type=>"runtime"},
-        {:name=>"redis", :requirement=>"0.12.1", :type=>"runtime"},
-        {:name=>"semver", :requirement=>"4.3.6", :type=>"runtime"},
-        {:name=>"serve-static", :requirement=>"1.10.0", :type=>"runtime"},
-        {:name=>"toml", :requirement=>"2.3.0", :type=>"runtime"}
-      ],
+    expect(described_class.analyse_contents('npm-shrinkwrap.json', load_fixture('npm-shrinkwrap.json'))).to include({
+      platform: "npm",
+      path: "npm-shrinkwrap.json",
       kind: 'lockfile',
       success: true
     })
+    expect(described_class.analyse_contents('npm-shrinkwrap.json', load_fixture('npm-shrinkwrap.json'))[:dependencies]).to include(
+      { name:"babel", requirement:"4.7.16", type:"runtime" },
+      { name:"body-parser", requirement:"1.13.3", type:"runtime" },
+      { name:"bugsnag", requirement:"1.6.5", type:"runtime" },
+      { name:"cookie-session", requirement:"1.2.0", type:"runtime" },
+      { name:"debug", requirement:"2.2.0", type:"development" },
+      { name:"deep-diff", requirement:"0.3.2", type:"runtime" },
+      { name:"deep-equal", requirement:"1.0.0", type:"runtime" },
+      { name:"express", requirement:"4.13.3", type:"runtime" },
+      { name:"express-session", requirement:"1.11.3", type:"runtime" },
+      { name:"jade", requirement:"1.11.0", type:"runtime" },
+      { name:"js-yaml", requirement:"3.4.0", type:"runtime" },
+      { name:"memwatch-next", requirement:"0.2.9", type:"runtime" },
+      { name:"multer", requirement:"0.1.8", type:"runtime" },
+      { name:"qs", requirement:"2.4.2", type:"runtime" },
+      { name:"redis", requirement:"0.12.1", type:"runtime" },
+      { name:"semver", requirement:"4.3.6", type:"runtime" },
+      { name:"serve-static", requirement:"1.10.0", type:"runtime" },
+      { name:"toml", requirement:"2.3.0", type:"runtime" }
+    )
   end
 
   it 'parses dependencies from yarn.lock', :vcr do


### PR DESCRIPTION
These files [have the same format](https://docs.npmjs.com/cli/v8/configuring-npm/package-lock-json#package-lockjson-vs-npm-shrinkwrapjson), so we can parse them the same way.