### PR TITLE
Update NuGet parser to handle dev dependencies

### DIFF
--- a/lib/bibliothecary/parsers/nuget.rb
+++ b/lib/bibliothecary/parsers/nuget.rb
@@ -108,7 +108,7 @@ module Bibliothecary
             requirement = dependency.nodes.detect{ |n| n.value == "Version" }&.text
           end
 
-          type = if dependency.nodes.first && dependency.nodes.first.nodes.include?("all") && dependency.nodes.first.value.include?("PrivateAssets")
+          type = if dependency.nodes.first && dependency.nodes.first.nodes.include?("all") && dependency.nodes.first.value.include?("PrivateAssets") || dependency.attributes[:PrivateAssets] == "All"
                    "development"
                  else
                    "runtime"

--- a/lib/bibliothecary/parsers/nuget.rb
+++ b/lib/bibliothecary/parsers/nuget.rb
@@ -92,7 +92,7 @@ module Bibliothecary
           {
             name: dependency.id,
             requirement: (dependency.version if dependency.respond_to? "version") || "*",
-            type: 'runtime'
+            type: dependency.respond_to?("developmentDependency") && dependency.developmentDependency ? 'development' : 'runtime'
           }
         end
       rescue

--- a/lib/bibliothecary/parsers/nuget.rb
+++ b/lib/bibliothecary/parsers/nuget.rb
@@ -92,7 +92,7 @@ module Bibliothecary
           {
             name: dependency.id,
             requirement: (dependency.version if dependency.respond_to? "version") || "*",
-            type: dependency.respond_to?("developmentDependency") && dependency.developmentDependency ? 'development' : 'runtime'
+            type: dependency.respond_to?("developmentDependency") && dependency.developmentDependency == "true" ? 'development' : 'runtime'
           }
         end
       rescue

--- a/lib/bibliothecary/parsers/nuget.rb
+++ b/lib/bibliothecary/parsers/nuget.rb
@@ -131,7 +131,7 @@ module Bibliothecary
           {
             name: dependency.id,
             requirement: dependency.attributes[:version] || '*',
-            type: 'runtime'
+            type: dependency.respond_to?("developmentDependency") && dependency.developmentDependency == "true" ? 'development' : 'runtime'
           }
         end
       rescue

--- a/lib/bibliothecary/parsers/nuget.rb
+++ b/lib/bibliothecary/parsers/nuget.rb
@@ -108,10 +108,16 @@ module Bibliothecary
             requirement = dependency.nodes.detect{ |n| n.value == "Version" }&.text
           end
 
+          type = if dependency.nodes.first && dependency.nodes.first.nodes.include?("all") && dependency.nodes.first.value.include?("PrivateAssets")
+                   "development"
+                 else
+                   "runtime"
+                 end
+
           {
             name: dependency.Include,
             requirement: requirement,
-            type: 'runtime'
+            type: type
           }
         end
         packages.uniq {|package| package[:name] }

--- a/spec/fixtures/example.csproj
+++ b/spec/fixtures/example.csproj
@@ -16,5 +16,8 @@
     <PackageReference Include="System.Resources.Extensions">
       <Version>4.7.0</Version>
     </PackageReference>
+    <PackageReference Include="Contoso.Utility.UsefulStuff" Version="3.6.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/spec/fixtures/example.nuspec
+++ b/spec/fixtures/example.nuspec
@@ -15,6 +15,7 @@
       <dependency id="FubuCore" version="3.2.0.3001" />
       <dependency id="HtmlTags"  version="[3.2.0.3001]" />
       <dependency id="DotNetZip" />
+      <dependency id="DevelopmentOnlyPackage" version="1.2.3" developmentDependency="true" />
     </dependencies>
   </metadata>
   <files>

--- a/spec/fixtures/packages.config
+++ b/spec/fixtures/packages.config
@@ -6,4 +6,5 @@
   <package id="Ninject" version="3.0.1.10" />
   <package id="Ninject.Web.Common" version="3.0.0.7" />
   <package id="WebActivator" version="1.5" />
+  <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/spec/parsers/nuget_spec.rb
+++ b/spec/parsers/nuget_spec.rb
@@ -857,7 +857,8 @@ describe Bibliothecary::Parsers::Nuget do
         { name: "Microsoft.Extensions.Logging.Debug", requirement: "1.1.1", type: "runtime" },
         { name: "Microsoft.Extensions.DependencyInjection", requirement: "1.1.1", type: "runtime" },
         { name: "Microsoft.VisualStudio.Web.BrowserLink", requirement: "1.1.0", type: "runtime" },
-        { name: "System.Resources.Extensions", requirement: "4.7.0", type: "runtime" }
+        { name: "System.Resources.Extensions", requirement: "4.7.0", type: "runtime" },
+        { name: "Contoso.Utility.UsefulStuff", requirement: "3.6.0", type: "development" }
       ],
       kind: 'manifest',
       success: true

--- a/spec/parsers/nuget_spec.rb
+++ b/spec/parsers/nuget_spec.rb
@@ -885,7 +885,8 @@ describe Bibliothecary::Parsers::Nuget do
       dependencies: [
         { name: "FubuCore", requirement: "3.2.0.3001", type: "runtime" },
         { name: "HtmlTags", requirement: "[3.2.0.3001]", type: "runtime" },
-        { name: "DotNetZip", requirement: "*", type: "runtime" }
+        { name: "DotNetZip", requirement: "*", type: "runtime" },
+        { name: "DevelopmentOnlyPackage", requirement: "1.2.3", type: "development" }
       ],
       kind: 'manifest',
       success: true

--- a/spec/parsers/nuget_spec.rb
+++ b/spec/parsers/nuget_spec.rb
@@ -838,7 +838,8 @@ describe Bibliothecary::Parsers::Nuget do
         { name: "Mvc3Futures", requirement: "3.0.20105.0", type: "runtime" },
         { name: "Ninject", requirement: "3.0.1.10", type: "runtime" },
         { name: "Ninject.Web.Common", requirement: "3.0.0.7", type: "runtime" },
-        { name: "WebActivator", requirement: "1.5", type: "runtime" }
+        { name: "WebActivator", requirement: "1.5", type: "runtime" },
+        { name: "Microsoft.Net.Compilers", requirement: "1.0.0", type: "development" }
       ],
       kind: 'manifest',
       success: true

--- a/spec/parsers/nuget_spec.rb
+++ b/spec/parsers/nuget_spec.rb
@@ -871,7 +871,7 @@ describe Bibliothecary::Parsers::Nuget do
       path: "example.csproj",
       dependencies: [
         { name: "Microsoft.AspNetCore.App", requirement: "*", type: "runtime" },
-        { name: "Microsoft.AspNetCore.Razor.Design", requirement: "2.2.0", type: "runtime" }
+        { name: "Microsoft.AspNetCore.Razor.Design", requirement: "2.2.0", type: "development" }
       ],
       kind: 'manifest',
       success: true


### PR DESCRIPTION
This adds support for the `developmentDependency` attribute from `packages.config` files:
- https://docs.microsoft.com/en-us/nuget/reference/packages-config#examples

It also adds support `PackageReference`elements as used in `.csproj` files:
- https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#controlling-dependency-assets

(Edit)
It also adds `developmentDependency` support for use in `.nuspec` files:
- https://docs.microsoft.com/en-us/nuget/reference/nuspec#developmentdependency