### PR TITLE
NPM: omit "//" comment keys in package.json

### DIFF
--- a/lib/bibliothecary/parsers/npm.rb
+++ b/lib/bibliothecary/parsers/npm.rb
@@ -74,8 +74,12 @@ module Bibliothecary
       def self.parse_manifest(file_contents, options: {})
         manifest = JSON.parse(file_contents)
         raise "appears to be a lockfile rather than manifest format" if manifest.key?('lockfileVersion')
-        map_dependencies(manifest, 'dependencies', 'runtime') +
-        map_dependencies(manifest, 'devDependencies', 'development')
+        
+        (
+          map_dependencies(manifest, 'dependencies', 'runtime') +
+          map_dependencies(manifest, 'devDependencies', 'development')
+        )
+          .reject { |dep| dep[:name] == "//" } # Omit comment keys. They are valid in package.json: https://groups.google.com/g/nodejs/c/NmL7jdeuw0M/m/yTqI05DRQrIJ
       end
 
       def self.parse_yarn_lock(file_contents, options: {})

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.3.5"
+  VERSION = "8.3.6"
 end

--- a/spec/fixtures/package.json
+++ b/spec/fixtures/package.json
@@ -10,6 +10,10 @@
   "author": "Mauro Pompilio",
   "license": "MIT",
   "dependencies": {
+    "//": [
+      "This is a valid",
+      "comment in NPM."
+    ],
     "babel": "^4.6.6"
   },
   "devDependencies": {


### PR DESCRIPTION
I stumbled across an obscure link to a mailing list that comments like this in `package.json` are valid, so we can skip them inside `dependencies`/etc when parsing deps.