### PR TITLE
Handle gradle renames that don't have a requirement in manifest.

### DIFF
--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -167,6 +167,15 @@ module Bibliothecary
               requirement: dep[-1],
               type: type
             }
+          elsif dep.count == 5
+            # get name from renamed package resolution "org:name -> renamed_org:name:version"
+            {
+              original_name: dep[0,2].join(":"),
+              original_requirement: "*",
+              name: dep[-3..-2].join(":"),
+              requirement: dep[-1],
+              type: type
+            }
           else
             # get name from version conflict resolution ("org:name:version -> version") and no-resolution ("org:name:version")
             {

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.3.7"
+  VERSION = "8.3.8"
 end

--- a/spec/fixtures/gradle-dependencies-q.txt
+++ b/spec/fixtures/gradle-dependencies-q.txt
@@ -907,6 +907,7 @@ runtimeClasspath - Runtime classpath of source set 'main'.
 |    +--- apache:commons-io:1.4 -> commons-io:commons-io:2.6
 |    +--- com.github.axet:threads:0.0.14
 |    \--- org.jsoup:jsoup:1.10.1
++--- apache:axis -> axis:axis:1.4 (*)
 +--- org.quartz-scheduler:quartz:2.3.0
 |    \--- com.mchange:mchange-commons-java:0.2.11
 +--- org.hibernate:hibernate-core:5.3.6.Final

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -422,19 +422,20 @@ RSpec.describe Bibliothecary::Parsers::Maven do
 
       runtime_classpath = deps[:dependencies].select {|item| item[:type] == "runtimeClasspath"}
 
-      expect(runtime_classpath.length).to eq 156
+      expect(runtime_classpath.length).to eq 157
       expect(runtime_classpath.select {|item| item[:name] == "com.google.guava:guava"}.length).to eq 1
 
-      # test rename resolution
-      renamed_dep = runtime_classpath.
-        select do |item| 
-          item[:name] == "commons-io:commons-io" && 
-          item[:original_name] == "apache:commons-io" &&
-          item[:requirement] == "2.6" &&
-          item[:original_requirement] == "1.4" 
+      # test rename resolutions
+      [
+        {name: "commons-io:commons-io", requirement: "2.6", original_name: "apache:commons-io", original_requirement: "1.4"},
+        {name: "axis:axis", requirement: "1.4", original_name: "apache:axis", original_requirement: "*"}
+      ].each do |dep|
+        renamed_dep = runtime_classpath.select do |d| 
+          d.slice(:name, :requirement, :original_name, :original_requirement) == dep.slice(:name, :requirement, :original_name, :original_requirement)
         end
-      expect(renamed_dep.length).to eq 1
-
+        expect(renamed_dep.length).to eq(1), "couldn't find dep '#{dep[:original_name]}' renamed to '#{dep[:name]}'"
+      end
+  
       test_runtime_only = deps[:dependencies].select {|item| item[:type] == "testRuntimeOnly"}
 
       expect(test_runtime_only.length).to eq 0


### PR DESCRIPTION
Followup to https://github.com/librariesio/bibliothecary/pull/544 and https://github.com/librariesio/bibliothecary/pull/547

Sometimes a rename in `gradle-dependencies-q.txt` won't have a version requirement in the original manifest, so this adds support to recognize those cases as well.