### PR TITLE
Gradle lockfile parser refactor to support aliases to projects

### DIFF
--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -155,7 +155,6 @@ module Bibliothecary
 
           # gradle can import on-disk projects and deps will be listed under them, e.g. `+--- project :pie2-testing`,
           # so we treat these projects as internal deps themselves (["internal:foo","0.0.0"])
-          # to avoid any crazy depth math, and so we know where their deps are coming from.
           if (project_match = line.match(GRADLE_PROJECT_REGEX))
             project_name = project_match[1]
             line = line.sub(GRADLE_PROJECT_REGEX, "__PROJECT_GROUP__:__PROJECT_NAME__:__PROJECT_REQUIREMENT__") # project names can have colons, which breaks our split(":") below, so sub it out until after we've parsed the line.

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -12,6 +12,11 @@ module Bibliothecary
       # "|    \\--- com.google.guava:guava:23.5-jre (*)"
       GRADLE_DEP_REGEX = /(\+---|\\---){1}/
 
+      # Dependencies that are on-disk projects, eg:
+      # \--- project :api:my-internal-project
+      # +--- my-group:my-alias:1.2.3 -> project :client (*)
+      GRADLE_PROJECT_REGEX = /project :(\S+)/
+
       # Builtin methods: https://docs.gradle.org/current/userguide/java_plugin.html#tab:configurations
       # Deprecated methods: https://docs.gradle.org/current/userguide/upgrading_version_6.html#sec:configuration_removal
       GRADLE_DEPENDENCY_METHODS = %w(api compile compileClasspath compileOnly compileOnlyApi implementation runtime runtimeClasspath runtimeOnly testCompile testCompileOnly testImplementation testRuntime testRuntimeOnly)
@@ -148,11 +153,28 @@ module Bibliothecary
 
           split = gradle_dep_match.captures[0]
 
+          # gradle can import on-disk projects and deps will be listed under them, e.g. `+--- project :pie2-testing`,
+          # so we treat these projects as internal deps themselves (["internal:foo","0.0.0"])
+          # to avoid any crazy depth math, and so we know where their deps are coming from.
+          if (project_match = line.match(GRADLE_PROJECT_REGEX))
+            project_name = project_match[1]
+            line = line.sub(GRADLE_PROJECT_REGEX, "__PROJECT_GROUP__:__PROJECT_NAME__:__PROJECT_REQUIREMENT__") # project names can have colons, which breaks our split(":") below, so sub it out until after we've parsed the line.
+          else
+            project_name = ""
+          end
+
           dep = line
             .split(split)[1].sub(/(\((c|n|\*)\))$/, "") # line ending legend: (c) means a dependency constraint, (n) means not resolved, or (*) means resolved previously, e.g. org.springframework.boot:spring-boot-starter-web:2.1.0.M3 (*)
             .sub(/ FAILED$/, "") # dependency could not be resolved (but still may have a version)
             .sub(" -> ", ":") # handle version arrow syntax
-            .strip.split(":")
+            .strip
+            .split(":")
+            .map do |part| 
+              part
+                .sub(/__PROJECT_GROUP__/, "internal")# give all projects a group namespace of "internal"
+                .sub(/__PROJECT_NAME__/, project_name)
+                .sub(/__PROJECT_REQUIREMENT__/, "1.0.0")  # give all projects a requirement of "1.0.0".
+            end # replace placeholders after we've parsed the line
 
           # A testImplementation line can look like this so just skip those
           # \--- org.springframework.security:spring-security-test (n)

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.3.9"
+  VERSION = "8.4.0"
 end

--- a/spec/fixtures/gradle-dependencies-q.txt
+++ b/spec/fixtures/gradle-dependencies-q.txt
@@ -1745,6 +1745,7 @@ testRuntimeClasspath - Runtime classpath of source set 'test'.
 +--- org.hsqldb:hsqldb:2.4.1
 +--- org.skyscreamer:jsonassert:1.5.0
 +--- org.springframework:spring-test:5.1.0.RC3
+|    +--- my-group:common-job-update-gateway-compress:5.0.2 -> project :client (*)
 |    \--- org.springframework:spring-core:5.1.0.RC3 (*)
 +--- org.json:json:20160810
 \--- project :api:cas-server-core-api-test-category

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -443,7 +443,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
 
       test_runtime_classpath = deps[:dependencies].select {|item| item[:type] == "testRuntimeClasspath"}
 
-      expect(test_runtime_classpath.length).to eq 187
+      expect(test_runtime_classpath.length).to eq 188
       expect(test_runtime_classpath.select {|item| item[:name] == "org.glassfish.jaxb:jaxb-runtime"}.length).to eq 1
 
 
@@ -459,6 +459,24 @@ RSpec.describe Bibliothecary::Parsers::Maven do
 
     it "excludes failed items with no version" do
       expect(described_class.parse_gradle_resolved("+--- org.projectlombok:lombok FAILED")).to eq []
+    end
+
+    it "includes local projects as deps with 'internal' group and '1.0.0' requirement" do
+      expect(described_class.parse_gradle_resolved("+--- project :api:my-internal-project")).to eq [{
+        name: "internal:api:my-internal-project",
+        requirement: "1.0.0",
+        type: nil
+      }]
+    end
+
+    it "includes aliases to local projects" do
+      expect(described_class.parse_gradle_resolved("|    +--- my-group:common-job-update-gateway-compress:5.0.2 -> project :client (*)")).to eq [{
+        name: "internal:client",
+        requirement: "1.0.0",
+        original_name: "my-group:common-job-update-gateway-compress",
+        original_requirement: "5.0.2",
+        type: nil
+      }]
     end
 
     it "includes failed items with a version" do


### PR DESCRIPTION
This adds support to parse projects in `gradle-dependencies-q.txt` as dependencies:

`|    +--- project :client (*)`

As well as aliases to projects:

`|    +--- my-group:my-alias-project-name:3.0.4 -> project :client (*)`

Although projects aren't the same as a regular library, they can be the parent of libraries in the dependency tree, so it's worth tracking them so you don't miss their child dependencies, with a group of `internal` and a requirement of `1.0.0`, e.g. `internal:client:1.0.0`