### PR TITLE
 Gradle lockfile parser: track "Project" names so we can interpolate them when needed later.

### DIFF
--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.4.0"
+  VERSION = "8.4.1"
 end

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -498,7 +498,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
     end
 
     it "properly interpolates self-referential project lines" do
-      gradle_dependencies_q = <<-GRADLE
+      gradle_dependencies_out = <<-GRADLE
 ------------------------------------------------------------
 Project ':submodules:test'
 ------------------------------------------------------------
@@ -506,7 +506,6 @@ Project ':submodules:test'
 compileClasspath - Compile classpath for source set 'main'.
 +--- project :
 |    \\--- io.qameta.allure:allure-test-filter:2.18.1 (*)
-\\--- org.slf4j:jcl-over-slf4j -> 1.7.36 (*)
 
 (c) - dependency constraint
 (*) - dependencies omitted (listed previously)
@@ -514,7 +513,7 @@ compileClasspath - Compile classpath for source set 'main'.
 A web-based, searchable dependency report is available by adding the --scan option.
 GRADLE
 
-      expect(described_class.parse_gradle_resolved(gradle_dependencies_q)).to eq [{
+      expect(described_class.parse_gradle_resolved(gradle_dependencies_out)).to eq [{
         name: "internal:submodules:test",
         requirement: "1.0.0",
         type: "compileClasspath"
@@ -522,11 +521,6 @@ GRADLE
       {
         name: "io.qameta.allure:allure-test-filter",
         requirement: "2.18.1",
-        type: "compileClasspath"
-      },
-      {
-        name: "org.slf4j:jcl-over-slf4j",
-        requirement: "1.7.36",
         type: "compileClasspath"
       }]
     end

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -427,9 +427,9 @@ RSpec.describe Bibliothecary::Parsers::Maven do
 
       # test rename resolutions
       [
-        {name: "commons-io:commons-io", requirement: "2.6", original_name: "apache:commons-io", original_requirement: "1.4"},
-        {name: "axis:axis", requirement: "1.4", original_name: "apache:axis", original_requirement: "*"},
-        {name: "axis:axis", requirement: "1.4", original_name: "another-alias-group:axis", original_requirement: "*"}
+        { name: "commons-io:commons-io", requirement: "2.6", original_name: "apache:commons-io", original_requirement: "1.4" },
+        { name: "axis:axis", requirement: "1.4", original_name: "apache:axis", original_requirement: "*" },
+        { name: "axis:axis", requirement: "1.4", original_name: "another-alias-group:axis", original_requirement: "*" }
       ].each do |dep|
         renamed_dep = runtime_classpath.select do |d| 
           d.slice(:name, :requirement, :original_name, :original_requirement) == dep.slice(:name, :requirement, :original_name, :original_requirement)

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -497,6 +497,40 @@ RSpec.describe Bibliothecary::Parsers::Maven do
 
     end
 
+    it "properly interpolates self-referential project lines" do
+      gradle_dependencies_q = <<-GRADLE
+------------------------------------------------------------
+Project ':submodules:test'
+------------------------------------------------------------
+
+compileClasspath - Compile classpath for source set 'main'.
++--- project :
+|    \\--- io.qameta.allure:allure-test-filter:2.18.1 (*)
+\\--- org.slf4j:jcl-over-slf4j -> 1.7.36 (*)
+
+(c) - dependency constraint
+(*) - dependencies omitted (listed previously)
+
+A web-based, searchable dependency report is available by adding the --scan option.
+GRADLE
+
+      expect(described_class.parse_gradle_resolved(gradle_dependencies_q)).to eq [{
+        name: "internal:submodules:test",
+        requirement: "1.0.0",
+        type: "compileClasspath"
+      },
+      {
+        name: "io.qameta.allure:allure-test-filter",
+        requirement: "2.18.1",
+        type: "compileClasspath"
+      },
+      {
+        name: "org.slf4j:jcl-over-slf4j",
+        requirement: "1.7.36",
+        type: "compileClasspath"
+      }]
+    end
+
     it "properly handles no version to resolved version syntax" do
       no_version_to_version = "\\--- org.springframework.security:spring-security-test -> 5.2.2.RELEASE"
       expect(described_class


### PR DESCRIPTION
It looks like `gradle dependencies` will sometimes output a project as a dependency **without a name**:

`+--- project :`

The most logical explanation is that the emptiness implies the current project's name, so we can interpolate that if we start tracking it.

Followup to https://github.com/librariesio/bibliothecary/pull/559