### PR TITLE
Replace colons in gradle project names with hyphens.

### DIFF
--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.4.1"
+  VERSION = "8.4.2"
 end

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -463,7 +463,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
 
     it "includes local projects as deps with 'internal' group and '1.0.0' requirement" do
       expect(described_class.parse_gradle_resolved("+--- project :api:my-internal-project")).to eq [{
-        name: "internal:api:my-internal-project",
+        name: "internal:api-my-internal-project",
         requirement: "1.0.0",
         type: nil
       }]
@@ -514,7 +514,7 @@ A web-based, searchable dependency report is available by adding the --scan opti
 GRADLE
 
       expect(described_class.parse_gradle_resolved(gradle_dependencies_out)).to eq [{
-        name: "internal:submodules:test",
+        name: "internal:submodules-test",
         requirement: "1.0.0",
         type: "compileClasspath"
       },


### PR DESCRIPTION
This makes it safer to deal with these as deps, given maven's artifact name conventions (group:name:version).

e.g. `+--- project :api:my-internal-project` -> will now be interpreted as -> `internal:api-my-internal-project:1.0.0`

Leaves a minuscule chance for project name collisions, but the chances are slim.

Q: should we go with a different delimiter than `-`?