### PR TITLE
Gradle lockfile parser: extract the line-ending regexp, and remove interpolation logic.

### DIFF
--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -14,7 +14,7 @@ module Bibliothecary
 
       # Project declaration lines so we know the current project name
       # e.g. "Project ':submodules:test'" (this example is a project nested in submodules/test/ folder)
-      GRADLE_PROJECT_DECLARATION_REGEX = /(?:Root project|Project) '?:([^\s']+)'?/
+      GRADLE_PROJECT_DECLARATION_REGEX = /(?:Root project|Project) '?:?([^\s']+)'?/
       
       # Dependencies that are on-disk projects, eg:
       # e.g. "\--- project :api:my-internal-project"

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -161,7 +161,7 @@ module Bibliothecary
           # gradle can import on-disk projects and deps will be listed under them, e.g. `+--- project :test:integration`,
           # so we treat these projects as "internal" deps with requirement of "1.0.0"
           if (project_match = line.match(GRADLE_PROJECT_REGEX))
-            # an empty project name is a self-referential project, and we don't need to track the manifest's project itself, e.g. "+--- project :"
+            # an empty project name is self-referential (i.e. a cycle), and we don't need to track the manifest's project itself, e.g. "+--- project :"
             next if project_match[1].nil? 
 
             # project names can have colons (e.g. for gradle projects in subfolders), which breaks maven artifact naming assumptions, so just replace them with hyphens.

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -14,7 +14,7 @@ module Bibliothecary
 
       # Project declaration lines so we know the current project name
       # e.g. "Project ':submodules:test'" (this example is a project nested in submodules/test/ folder)
-      GRADLE_PROJECT_DECLARATION_REGEX = /Project '?:([^\s']+)'?/
+      GRADLE_PROJECT_DECLARATION_REGEX = /(?:Root project|Project) '?:([^\s']+)'?/
       
       # Dependencies that are on-disk projects, eg:
       # e.g. "\--- project :api:my-internal-project"

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -21,13 +21,13 @@ module Bibliothecary
       # e.g. "+--- my-group:my-alias:1.2.3 -> project :client (*)"
       GRADLE_PROJECT_REGEX = /project :(\S+)?/
 
+      # line ending legend: (c) means a dependency constraint, (n) means not resolved, or (*) means resolved previously, e.g. org.springframework.boot:spring-boot-starter-web:2.1.0.M3 (*)
+      # e.g. the "(n)" in "+--- my-group:my-name:1.2.3 (n)"
+      GRADLE_LINE_ENDING_REGEX = /(\((c|n|\*)\))$/
+
       # Builtin methods: https://docs.gradle.org/current/userguide/java_plugin.html#tab:configurations
       # Deprecated methods: https://docs.gradle.org/current/userguide/upgrading_version_6.html#sec:configuration_removal
       GRADLE_DEPENDENCY_METHODS = %w(api compile compileClasspath compileOnly compileOnlyApi implementation runtime runtimeClasspath runtimeOnly testCompile testCompileOnly testImplementation testRuntime testRuntimeOnly)
-
-      # line ending legend: (c) means a dependency constraint, (n) means not resolved, or (*) means resolved previously, e.g. org.springframework.boot:spring-boot-starter-web:2.1.0.M3 (*)
-      # e.g. the "(n)" in "+--- my-group:my-name:1.2.3 (n)"
-      GRADLE_LINE_ENDING = /(\((c|n|\*)\))$/
 
       # Intentionally overly-simplified regexes to scrape deps from build.gradle (Groovy) and build.gradle.kts (Kotlin) files. 
       # To be truly useful bibliothecary would need full Groovy / Kotlin parsers that speaks Gradle, 
@@ -178,7 +178,7 @@ module Bibliothecary
 
           dep = line
             .split(split)[1]
-            .sub(GRADLE_LINE_ENDING, "")
+            .sub(GRADLE_LINE_ENDING_REGEX, "")
             .sub(/ FAILED$/, "") # dependency could not be resolved (but still may have a version)
             .sub(" -> ", ":") # handle version arrow syntax
             .strip

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -25,6 +25,10 @@ module Bibliothecary
       # Deprecated methods: https://docs.gradle.org/current/userguide/upgrading_version_6.html#sec:configuration_removal
       GRADLE_DEPENDENCY_METHODS = %w(api compile compileClasspath compileOnly compileOnlyApi implementation runtime runtimeClasspath runtimeOnly testCompile testCompileOnly testImplementation testRuntime testRuntimeOnly)
 
+      # line ending legend: (c) means a dependency constraint, (n) means not resolved, or (*) means resolved previously, e.g. org.springframework.boot:spring-boot-starter-web:2.1.0.M3 (*)
+      # e.g. the "(n)" in "+--- my-group:my-name:1.2.3 (n)"
+      GRADLE_LINE_ENDING = /(\((c|n|\*)\))$/
+
       # Intentionally overly-simplified regexes to scrape deps from build.gradle (Groovy) and build.gradle.kts (Kotlin) files. 
       # To be truly useful bibliothecary would need full Groovy / Kotlin parsers that speaks Gradle, 
       # because the Groovy and Kotlin DSLs have many dynamic ways of declaring dependencies.
@@ -173,7 +177,8 @@ module Bibliothecary
           end
 
           dep = line
-            .split(split)[1].sub(/(\((c|n|\*)\))$/, "") # line ending legend: (c) means a dependency constraint, (n) means not resolved, or (*) means resolved previously, e.g. org.springframework.boot:spring-boot-starter-web:2.1.0.M3 (*)
+            .split(split)[1]
+            .sub(GRADLE_LINE_ENDING, "")
             .sub(/ FAILED$/, "") # dependency could not be resolved (but still may have a version)
             .sub(" -> ", ":") # handle version arrow syntax
             .strip

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.4.2"
+  VERSION = "8.4.3"
 end

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -504,7 +504,7 @@ Project ':submodules:test'
 ------------------------------------------------------------
 
 compileClasspath - Compile classpath for source set 'main'.
-+--- project :
++--- project : (*)
 |    \\--- io.qameta.allure:allure-test-filter:2.18.1 (*)
 
 (c) - dependency constraint

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -497,7 +497,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
 
     end
 
-    it "properly interpolates self-referential root project lines" do
+    it "skips self-referential project lines" do
       gradle_dependencies_out = <<-GRADLE
 ------------------------------------------------------------
 Root project 'myorg-common'
@@ -507,33 +507,7 @@ compileClasspath - Compile classpath for source set 'main'.
 +--- project : (*)
 GRADLE
 
-      expect(described_class.parse_gradle_resolved(gradle_dependencies_out)).to eq [{
-        name: "internal:myorg/common",
-        requirement: "1.0.0",
-        type: "compileClasspath"
-      },
-    end
-
-    it "properly interpolates self-referential project lines" do
-      gradle_dependencies_out = <<-GRADLE
-------------------------------------------------------------
-Project ':submodules:test'
-------------------------------------------------------------
-
-compileClasspath - Compile classpath for source set 'main'.
-+--- project : (*)
-GRADLE
-
-      expect(described_class.parse_gradle_resolved(gradle_dependencies_out)).to eq [{
-        name: "internal:submodules-test",
-        requirement: "1.0.0",
-        type: "compileClasspath"
-      },
-      {
-        name: "io.qameta.allure:allure-test-filter",
-        requirement: "2.18.1",
-        type: "compileClasspath"
-      }]
+      expect(described_class.parse_gradle_resolved(gradle_dependencies_out)).to eq []
     end
 
     it "properly handles no version to resolved version syntax" do

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -497,6 +497,23 @@ RSpec.describe Bibliothecary::Parsers::Maven do
 
     end
 
+    it "captures root project lines" do
+      gradle_dependencies_out = <<-GRADLE
+------------------------------------------------------------
+Root project 'myorg-common'
+------------------------------------------------------------            
+
+compileClasspath - Compile classpath for source set 'main'.
++--- project : (*)
+GRADLE
+
+      expect(described_class.parse_gradle_resolved(gradle_dependencies_out)).to eq [{
+        name: "internal:myorg/common",
+        requirement: "1.0.0",
+        type: "compileClasspath"
+      },
+    end
+
     it "properly interpolates self-referential project lines" do
       gradle_dependencies_out = <<-GRADLE
 ------------------------------------------------------------
@@ -505,12 +522,6 @@ Project ':submodules:test'
 
 compileClasspath - Compile classpath for source set 'main'.
 +--- project : (*)
-|    \\--- io.qameta.allure:allure-test-filter:2.18.1 (*)
-
-(c) - dependency constraint
-(*) - dependencies omitted (listed previously)
-
-A web-based, searchable dependency report is available by adding the --scan option.
 GRADLE
 
       expect(described_class.parse_gradle_resolved(gradle_dependencies_out)).to eq [{

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -500,7 +500,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
     it "skips self-referential project lines" do
       gradle_dependencies_out = <<-GRADLE
 ------------------------------------------------------------
-Root project 'myorg-common'
+Project ':submodules:test'
 ------------------------------------------------------------            
 
 compileClasspath - Compile classpath for source set 'main'.

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -497,7 +497,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
 
     end
 
-    it "captures root project lines" do
+    it "properly interpolates self-referential root project lines" do
       gradle_dependencies_out = <<-GRADLE
 ------------------------------------------------------------
 Root project 'myorg-common'


### PR DESCRIPTION
* extract line-ending regexp so it's reusable elsewhere
* also, remove the "interpolate the project name" logic that was added in https://github.com/librariesio/bibliothecary/pull/560, because these are cycles [as confirmed by the gradle tests](https://github.com/gradle/gradle/blob/d1afb35abdbb2065de3086da885df8071b30049a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy#L1697-L1753), so there's no reason to track them