### PR TITLE
Remove unnecessary sorting on gradle-dependencies-q.txt deps

### DIFF
--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -209,8 +209,6 @@ module Bibliothecary
           end
         end
           .compact
-          # Prefer duplicate deps with the aliased ones first, so we don't lose the aliases in the next uniq step.
-          .sort_by { |dep| dep.key?(:original_name) || dep.key?(:original_requirement) ? 0 : 1 }
           .uniq { |item| item.values_at(:name, :requirement, :type, :original_name, :original_requirement) }
       end
 

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.4.3"
+  VERSION = "8.4.4"
 end


### PR DESCRIPTION
@travatomic found a case where the sorting on gradle-dependencies-q.txt is non-deterministic on different platforms, which made us realize that the sorting done here is no longer necessary after https://github.com/librariesio/bibliothecary/pull/558  (in that PR, we expanded the uniqueness by adding original_name/original_requirement, which makes the sorting pointless)