### PR TITLE
Remove Byte Order Marks from beginning of file contents before parsing.

### DIFF
--- a/lib/bibliothecary/file_info.rb
+++ b/lib/bibliothecary/file_info.rb
@@ -17,7 +17,8 @@ module Bibliothecary
             # file that's actually on the filesystem
             nil
           else
-            File.open(@full_path).read
+            # Remove any Byte Order Marks so JSON, etc don't fail while reading them.
+            File.open(@full_path).read.sub(/^\xEF\xBB\xBF/, '')
           end
         end
     end

--- a/lib/bibliothecary/runner.rb
+++ b/lib/bibliothecary/runner.rb
@@ -116,6 +116,9 @@ module Bibliothecary
 
     # Read a manifest file and extract the list of dependencies from that file.
     def analyse_file(file_path, contents)
+      # Remove any Byte Order Marks so JSON, etc don't fail while reading them.
+      contents = contents.sub(/^\xEF\xBB\xBF/, '')
+
       package_managers.select { |pm| pm.match?(file_path, contents) }.map do |pm|
         pm.analyse_contents(file_path, contents, options: @options)
       end.flatten.uniq.compact

--- a/lib/bibliothecary/runner/multi_manifest_filter.rb
+++ b/lib/bibliothecary/runner/multi_manifest_filter.rb
@@ -71,7 +71,9 @@ module Bibliothecary
 
       def each_analysis_and_rfis
         @multiple_file_entries.each do |file|
-          analysis = @runner.analyse_file(file, File.read(File.join(@path, file)))
+          # Remove any Byte Order Marks so JSON, etc don't fail while reading them.
+          contents = File.read(File.join(@path, file)).sub(/^\xEF\xBB\xBF/, '')
+          analysis = @runner.analyse_file(file, contents)
           rfis_for_file = @related_files_info_entries.find_all { |rfi| rfi.lockfiles.include?(file) }
 
           yield analysis, rfis_for_file

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.4.4"
+  VERSION = "8.4.5"
 end

--- a/spec/bibliothecary_spec.rb
+++ b/spec/bibliothecary_spec.rb
@@ -72,6 +72,14 @@ describe Bibliothecary do
     }])
   end
 
+  it 'analyses contents of a file with a Byte Order Mark' do
+    file_with_byte_order_mark = [65279].pack("U*") + load_fixture('package.json')
+    result = described_class.analyse_file('package.json', file_with_byte_order_mark)
+
+    expect(result[0][:error_message]).to eq(nil)
+    expect(result[0][:dependencies].length).to eq(2)
+  end
+
   it "aliases analyse and analyse_file" do
     expect(Bibliothecary.method(:analyse)).to eq(Bibliothecary.method(:analyze))
     expect(Bibliothecary.method(:analyse_file)).to eq(Bibliothecary.method(:analyze_file))


### PR DESCRIPTION
Fixes parsing of files like this cyclonedx.json, which have a Byte Order Mark at the beginning of the file:

``` ruby
File.read("cyclonedx.json").unpack("U*")[0,10]
=> [65279, 123, 13, 10, 32, 32, 32, 32, 34, 98]

JSON.parse(File.read("cyclonedx.json"))
JSON::ParserError: Empty input (after ) at line 1, column 1 [parse.c:1116] in '{
    "bomFormat": "CycloneDX",
    "specVersion": "1.4",
    "version": 1,
    "metadata": {
        "tools": [
            {
                "vendor": "CycloneDX",
                "name": "Node.js module",
```