### PR TITLE
Handle non-utf8 files when removing BOM too, and DRY up into a helper method.

### DIFF
--- a/lib/bibliothecary.rb
+++ b/lib/bibliothecary.rb
@@ -75,6 +75,12 @@ module Bibliothecary
     configuration.ignored_files
   end
 
+  def self.utf8_string(string)
+    string
+      .force_encoding("UTF-8") # treat all strings as utf8
+      .sub(/^\xEF\xBB\xBF/, '') # remove any Byte Order Marks so JSON, etc don't fail while parsing them.
+  end
+
   class << self
     attr_writer :configuration
     alias analyze analyse

--- a/lib/bibliothecary/file_info.rb
+++ b/lib/bibliothecary/file_info.rb
@@ -17,8 +17,7 @@ module Bibliothecary
             # file that's actually on the filesystem
             nil
           else
-            # Remove any Byte Order Marks so JSON, etc don't fail while parsing them.
-            File.open(@full_path).read.sub(/^\xEF\xBB\xBF/, '')
+            contents = Bibliothecary.utf8_string(File.open(@full_path).read)
           end
         end
     end

--- a/lib/bibliothecary/runner.rb
+++ b/lib/bibliothecary/runner.rb
@@ -116,8 +116,7 @@ module Bibliothecary
 
     # Read a manifest file and extract the list of dependencies from that file.
     def analyse_file(file_path, contents)
-      # Remove any Byte Order Marks so JSON, etc don't fail while parsing them.
-      contents = contents.sub(/^\xEF\xBB\xBF/, '')
+      contents = Bibliothecary.utf8_string(contents)
 
       package_managers.select { |pm| pm.match?(file_path, contents) }.map do |pm|
         pm.analyse_contents(file_path, contents, options: @options)

--- a/lib/bibliothecary/runner/multi_manifest_filter.rb
+++ b/lib/bibliothecary/runner/multi_manifest_filter.rb
@@ -71,8 +71,7 @@ module Bibliothecary
 
       def each_analysis_and_rfis
         @multiple_file_entries.each do |file|
-          # Remove any Byte Order Marks so JSON, etc don't fail while parsing them.
-          contents = File.read(File.join(@path, file)).sub(/^\xEF\xBB\xBF/, '')
+          contents = Bibliothecary.utf8_string(File.join(@path, file))
           analysis = @runner.analyse_file(file, contents)
           rfis_for_file = @related_files_info_entries.find_all { |rfi| rfi.lockfiles.include?(file) }
 

--- a/lib/bibliothecary/runner/multi_manifest_filter.rb
+++ b/lib/bibliothecary/runner/multi_manifest_filter.rb
@@ -71,7 +71,7 @@ module Bibliothecary
 
       def each_analysis_and_rfis
         @multiple_file_entries.each do |file|
-          contents = Bibliothecary.utf8_string(File.join(@path, file))
+          contents = Bibliothecary.utf8_string(File.read(File.join(@path, file)))
           analysis = @runner.analyse_file(file, contents)
           rfis_for_file = @related_files_info_entries.find_all { |rfi| rfi.lockfiles.include?(file) }
 

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.4.5"
+  VERSION = "8.4.6"
 end

--- a/spec/bibliothecary_spec.rb
+++ b/spec/bibliothecary_spec.rb
@@ -73,11 +73,19 @@ describe Bibliothecary do
   end
 
   it 'analyses contents of a file with a Byte Order Mark' do
-    file_with_byte_order_mark = [65279].pack("U*") + load_fixture('package.json')
+    file_with_byte_order_mark = "\xEF\xBB\xBF{}"
     result = described_class.analyse_file('package.json', file_with_byte_order_mark)
 
     expect(result[0][:error_message]).to eq(nil)
-    expect(result[0][:dependencies].length).to eq(2)
+    expect(result[0][:dependencies].length).to eq(0)
+  end
+
+  it 'analyses contents of a file with non-UTF8 encodings' do
+    ascii_8bit_encoded_file = "\xEF\xBB\xBF{}".force_encoding(Encoding::ASCII_8BIT)
+    result = described_class.analyse_file('package.json', ascii_8bit_encoded_file)
+
+    expect(result[0][:error_message]).to eq(nil)
+    expect(result[0][:dependencies].length).to eq(0)
   end
 
   it "aliases analyse and analyse_file" do


### PR DESCRIPTION
Followup to https://github.com/librariesio/bibliothecary/pull/564

We saw an error when an ASCII-8BIT yarn.lock file was run against bibliothecary after adding the "remove BOM" logic:

```
Encoding::CompatibilityError: incompatible encoding regexp match (UTF-8 regexp with ASCII-8BIT string)
```

We need to force the string's encoding to be utf8 before regex-ing it. ASCII-8BIT is fine to force, but if we need to support less common encodings like `utf-32be` in the future, we'll probably need to call `encode()` on the string too so it's properly encoded.