### PR TITLE
Maven.extract_pom_info: add support for more lookup variable namespaces.

### DIFF
--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -322,6 +322,9 @@ module Bibliothecary
         extract_pom_dep_info(xml, xml, location, parent_properties)
       end
 
+      # TODO: it might be worth renaming parent_properties to parent_elements
+      # so that more can be inherited from the parent pom than just <properties>
+      # here (see https://maven.apache.org/pom.html#inheritance)
       def self.extract_pom_dep_info(xml, dependency, name, parent_properties = {})
         field = dependency.locate(name).first
         return nil if field.nil?

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -363,7 +363,10 @@ module Bibliothecary
         return "${#{property_name}}" if !xml.respond_to?("properties") && parent_properties.empty? && xml.locate(non_prop_name).empty?
 
         prop_field = xml.properties.locate(property_name).first if xml.respond_to?("properties")
-        parent_prop = parent_properties[property_name]
+        parent_prop = parent_properties[property_name] ||                 # e.g. "${foo}"
+          parent_properties[property_name.sub(/^project\./, '')] ||       # e.g. "${project.foo}"
+          parent_properties[property_name.sub(/^project\.parent\./, '')]  # e.g. "${project.parent.foo}"
+
         if prop_field
           prop_field.nodes.first
         elsif parent_prop

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.5.0"
+  VERSION = "8.5.1"
 end


### PR DESCRIPTION
In `Bibliothecary::Parsers::Maven.extract_pom_info` currently we allow you to lookup a pom element with a variable and we'll try to interpolate it, e.g.:

``` xml
<scm><url>${scm.url}</url></scm>
```

But you might also want to reference the element in the project namespace:

``` xml
<scm><url>${project.scm.url}</url></scm>
```

Or in the project's parent namespace:

``` xml
<scm><url>${project.parent.scm.url}</url></scm>
```

This adds support for the latter 2 lookups.

(interpolation was originally added in https://github.com/librariesio/bibliothecary/pull/456)