### PR TITLE
pyproject.toml: support PEP621 projects too

### DIFF
--- a/lib/bibliothecary/parsers/pypi.rb
+++ b/lib/bibliothecary/parsers/pypi.rb
@@ -108,6 +108,8 @@ module Bibliothecary
         pep621_deps = pep621_manifest.fetch('dependencies', []).map { |d| parse_pep_508_dep_spec(d) }
         deps += map_dependencies(pep621_deps, 'runtime')
 
+        # We're combining both poetry+PEP621 deps instead of making them mutually exclusive, until we
+        # find a reason not to ingest them both.
         deps
       end
 

--- a/lib/bibliothecary/parsers/pypi.rb
+++ b/lib/bibliothecary/parsers/pypi.rb
@@ -111,7 +111,7 @@ module Bibliothecary
         deps
       end
 
-      # TODO: this was deprecated in 8.5.2. Remove this in any major version bump >= 9.*
+      # TODO: this was deprecated in 8.6.0. Remove this in any major version bump >= 9.*
       def self.parse_poetry(file_contents, options: {})
         puts "Warning: parse_poetry() is deprecated, use parse_pyproject() instead."
         parse_pyproject(file_contents, options)

--- a/lib/bibliothecary/parsers/pypi.rb
+++ b/lib/bibliothecary/parsers/pypi.rb
@@ -110,7 +110,7 @@ module Bibliothecary
 
         # We're combining both poetry+PEP621 deps instead of making them mutually exclusive, until we
         # find a reason not to ingest them both.
-        deps
+        deps.uniq
       end
 
       # TODO: this was deprecated in 8.6.0. Remove this in any major version bump >= 9.*

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.5.1"
+  VERSION = "8.6.0"
 end

--- a/spec/parsers/pypi_spec.rb
+++ b/spec/parsers/pypi_spec.rb
@@ -315,7 +315,6 @@ git://what@::/:/:/
 [project]
 name = "a_pep621_project"
 version = "0.1.0"
-requires-python = ">=3.10"
 dependencies = [
     "black",
     "isort",

--- a/spec/parsers/pypi_spec.rb
+++ b/spec/parsers/pypi_spec.rb
@@ -331,9 +331,9 @@ dependencies = [
       dependencies: [
         {name: "black", requirement: "*", type: "runtime"}, 
         {name: "isort", requirement: "*", type: "runtime"}, 
-        {name: "click == 8.1.3", requirement: "*", type: "runtime"}, 
-        {name: "pytest == 7.2.1", requirement: "*", type: "runtime"}, 
-        {name: "python-gitlab == 3.12.0", requirement: "*", type: "runtime"}
+        {name: "click", requirement: "== 8.1.3", type: "runtime"}, 
+        {name: "pytest", requirement: "== 7.2.1", type: "runtime"}, 
+        {name: "python-gitlab", requirement: "== 3.12.0", type: "runtime"}
       ],
       kind: 'manifest',
       success: true

--- a/spec/parsers/pypi_spec.rb
+++ b/spec/parsers/pypi_spec.rb
@@ -309,6 +309,37 @@ git://what@::/:/:/
     })
   end
 
+  # https://packaging.python.org/en/latest/specifications/declaring-project-metadata/#declaring-project-metadata
+  it 'handles pyproject.toml with pep621-style deps' do
+    source = <<~FILE
+[project]
+name = "a_pep621_project"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "black",
+    "isort",
+    "click == 8.1.3",
+    "pytest == 7.2.1",
+    "python-gitlab == 3.12.0",
+]    
+    FILE
+
+    expect(described_class.analyse_contents('pyproject.toml', source)).to eq({
+      platform: "pypi",
+      path: "pyproject.toml",
+      dependencies: [
+        {name: "black", requirement: "*", type: "runtime"}, 
+        {name: "isort", requirement: "*", type: "runtime"}, 
+        {name: "click == 8.1.3", requirement: "*", type: "runtime"}, 
+        {name: "pytest == 7.2.1", requirement: "*", type: "runtime"}, 
+        {name: "python-gitlab == 3.12.0", requirement: "*", type: "runtime"}
+      ],
+      kind: 'manifest',
+      success: true
+    })
+  end
+
   it 'parses dependencies from Poetry.lock' do
     expect(described_class.analyse_contents('poetry.lock', load_fixture('poetry.lock'))).to eq({
       platform: "pypi",

--- a/spec/parsers/pypi_spec.rb
+++ b/spec/parsers/pypi_spec.rb
@@ -319,10 +319,11 @@ requires-python = ">=3.10"
 dependencies = [
     "black",
     "isort",
-    "click == 8.1.3",
     "pytest == 7.2.1",
     "python-gitlab == 3.12.0",
-]    
+    "Click~=8.1.0",
+    "marshmallow-dataclass[union]~=8.5.6",
+]
     FILE
 
     expect(described_class.analyse_contents('pyproject.toml', source)).to eq({
@@ -331,9 +332,10 @@ dependencies = [
       dependencies: [
         {name: "black", requirement: "*", type: "runtime"}, 
         {name: "isort", requirement: "*", type: "runtime"}, 
-        {name: "click", requirement: "== 8.1.3", type: "runtime"}, 
         {name: "pytest", requirement: "== 7.2.1", type: "runtime"}, 
-        {name: "python-gitlab", requirement: "== 3.12.0", type: "runtime"}
+        {name: "python-gitlab", requirement: "== 3.12.0", type: "runtime"},
+        {name: "Click", requirement: "~=8.1.0", type: "runtime"},
+        {name: "marshmallow-dataclass", requirement: "[union]~=8.5.6", type: "runtime"}
       ],
       kind: 'manifest',
       success: true


### PR DESCRIPTION
`pyproject.toml` can include poetry metadata, but it can also include project metadata according to [PEP 621](https://packaging.python.org/en/latest/specifications/declaring-project-metadata/), under the `[project]` field. This adds support for those `[project.dependencies]` deps.