### PR TITLE
Add support for optional field in Maven POM parser

### DIFF
--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -268,11 +268,15 @@ module Bibliothecary
         [].tap do |deps|
           ['dependencies/dependency', 'dependencyManagement/dependencies/dependency'].each do |deps_xpath|
             xml.locate(deps_xpath).each do |dep|
-              deps.push({
+              dep_hash = {
                 name: "#{extract_pom_dep_info(xml, dep, 'groupId', parent_properties)}:#{extract_pom_dep_info(xml, dep, 'artifactId', parent_properties)}",
                 requirement: extract_pom_dep_info(xml, dep, 'version', parent_properties),
-                type: extract_pom_dep_info(xml, dep, 'scope', parent_properties) || 'runtime'
-              })
+                type: extract_pom_dep_info(xml, dep, 'scope', parent_properties) || 'runtime',
+              }
+              # optional field is, itself, optional, and will be either "true" or "false"
+              optional = extract_pom_dep_info(xml, dep, 'optional', parent_properties)
+              dep_hash[:optional] = optional == "true" unless optional.nil?
+              deps.push(dep_hash)
             end
           end
         end

--- a/spec/fixtures/pom.xml
+++ b/spec/fixtures/pom.xml
@@ -287,6 +287,18 @@
             <artifactId>recursive</artifactId>
             <version>${recursive.test}</version>
         </dependency>
+        <dependency>
+            <groupId>io.libraries</groupId>
+            <artifactId>optional</artifactId>
+            <version>${optional.test}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.libraries</groupId>
+            <artifactId>not-optional</artifactId>
+            <version>${not-optional.test}</version>
+            <optional>false</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -91,6 +91,8 @@ RSpec.describe Bibliothecary::Parsers::Maven do
         { name: "org.mockito:mockito-all", requirement: "1.8.4", type: "test" },
         { name: "io.libraries:bibliothecary", requirement: "${bibliothecary.version}", type: "test" },
         { name: "io.libraries:recursive", requirement: "${recursive.test}", type: "runtime" },
+        { name: "io.libraries:optional", requirement: "${optional.test}", type: "runtime", optional: true },
+        { name: "io.libraries:not-optional", requirement: "${not-optional.test}", type: "runtime", optional: false },
         # From dependencyManagement section
         { name: "org.apache.ant:ant", requirement: "1.9.2", type: "runtime" },
         { name: "commons-lang:commons-lang",requirement: "2.6", type: "runtime" }


### PR DESCRIPTION
In coordination with [this documentation](https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html#how-do-i-use-the-optional-tag), this is to add support for the optional `optional` field in the Maven POM dependency parser.