### PR TITLE
Strip ansi color codes from maven-dependency-tree.txt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 source 'https://rubygems.org'
 
+# Temporarily pegging to HEAD until 0.2.1 is released: https://github.com/piotrmurach/strings-ansi/pull/2
+gem "strings-ansi", ref: "35d0c9430cf0a8022dc12bdab005bce296cb9f00", git: "git@github.com:piotrmurach/strings-ansi.git"
+
 # Specify your gem's dependencies in bibliothecary.gemspec
 gemspec
 

--- a/bibliothecary.gemspec
+++ b/bibliothecary.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "deb_control"
   spec.add_dependency "sdl4r"
   spec.add_dependency "commander"
-  spec.add_dependency "strings-ansi"
+  spec.add_dependency "strings-ansi" # NB this is also pegged to a git sha in Gemfile temporarily.  
   spec.add_dependency "strings"
   spec.add_dependency "packageurl-ruby"
 

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -221,8 +221,11 @@ module Bibliothecary
       end
 
       def self.parse_maven_tree(file_contents, options: {})
-        file_contents = file_contents.gsub(/\r\n?/, "\n")
-        captures = file_contents.scan(/^\[INFO\](?:(?:\+-)|\||(?:\\-)|\s)+((?:[\w\.-]+:)+[\w\.\-${}]+)/).flatten.uniq
+        captures = Strings::ANSI.sanitize(file_contents)
+          .gsub(/\r\n?/, "\n")
+          .scan(/^\[INFO\](?:(?:\+-)|\||(?:\\-)|\s)+((?:[\w\.-]+:)+[\w\.\-${}]+)/)
+          .flatten
+          .uniq
 
         deps = captures.map do |item|
           parts = item.split(":")

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.6.0"
+  VERSION = "8.6.1"
 end

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -557,6 +557,20 @@ GRADLE
       expect(output).to eq [{ name: "net.sourceforge.pmd:pmd-scala_2.12", requirement: "${someVariable}", type: "jar" }]
     end
 
+    it "parses dependencies with ansi color codes by stripping the codes" do
+      output = described_class.parse_maven_tree(%Q!
+[\e[1;34mINFO\e[m] net.sourceforge.pmd:pmd-core:jar:6.32.0-SNAPSHOT
+[\e[1;34mINFO\e[m] +- org.apache.ant:ant:jar:1.10.9:provided
+[\e[1;34mINFO\e[m] |  +- net.sourceforge.pmd:pmd:pom:6.32.0-SNAPSHOT:provided
+[\e[1;34mINFO\e[m] +- net.java.dev.javacc:javacc:jar:5.0:provided!)
+
+      expect(output).to eq [
+        { name: "org.apache.ant:ant", requirement: "1.10.9", type: "provided" },
+        { name: "net.sourceforge.pmd:pmd", requirement: "6.32.0-SNAPSHOT", type: "provided" },
+        { name: "net.java.dev.javacc:javacc", requirement: "5.0", type: "provided" },
+      ]
+    end
+
     it 'parses dependencies from gradle-dependencies-q.txt, generated from build.gradle.kts' do
       # This output should be the same format as from build.gradle, but including it just to have a fixture from build.gradle.kts documented.
       deps = described_class.analyse_contents('gradle-dependencies-q.txt', load_fixture('gradle_with_kotlin/gradle-dependencies-q.txt'))


### PR DESCRIPTION
* pegs us to an unpublished git sha of `strings-ansi` gem that supports stripping ansi color codes
* use the gem to sanitize input from `maven-dependency-tree.txt`