### PR TITLE
Nuget: ignore type="Project" deps in packages.lock.json

### DIFF
--- a/lib/bibliothecary/parsers/nuget.rb
+++ b/lib/bibliothecary/parsers/nuget.rb
@@ -65,15 +65,17 @@ module Bibliothecary
 
         frameworks = {}
         manifest.fetch('dependencies',[]).each do |framework, deps|
-          frameworks[framework] = deps.map do |name, details|
-            {
-              name: name,
-              # 'resolved' has been set in all examples so far
-              # so fallback to requested is pure paranoia
-              requirement: details.fetch('resolved', details.fetch('requested', '*')),
-              type: 'runtime'
-            }
-          end
+          frameworks[framework] = deps
+            .reject { |_name, details| details["type"] == "Project" } # Projects do not have versions
+            .map do |name, details|
+              {
+                name: name,
+                # 'resolved' has been set in all examples so far
+                # so fallback to requested is pure paranoia
+                requirement: details.fetch('resolved', details.fetch('requested', '*')),
+                type: 'runtime'
+              }
+            end
         end
 
         if frameworks.size > 0

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.7.0"
+  VERSION = "8.7.1"
 end

--- a/spec/fixtures/packages.lock.json
+++ b/spec/fixtures/packages.lock.json
@@ -1872,6 +1872,12 @@
           "System.Security.Principal.Windows": "4.5.0"
         }
       },
+      "Bibliothecary.Project": {
+        "type": "Project",
+        "dependencies": {
+          "FluentMigrator": "[1.6.2.1, )"
+        }
+      },
       "NETStandard.Library": {
         "type": "Transitive",
         "resolved": "2.0.3",


### PR DESCRIPTION
Nuget projects can show up in Nuget lockfiles as dependencies, but they don't have versions and are not the same as packages, so bibliothecary can ignore them.