### PR TITLE
fix: [sc-37248] Maven packages created with spaces in front

### DIFF
--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -254,6 +254,10 @@ module Bibliothecary
       end
 
       def self.parse_resolved_dep_line(line)
+        # filter out anythinmg that doesn't look like a
+        # resolved dep line
+        return unless line[/  .*:[^-]+-- /]
+
         dep_parts = line.strip.split(":")
         return unless dep_parts.length == 5
         # org.springframework.boot:spring-boot-starter-web:jar:2.0.3.RELEASE:compile[36m -- module spring.boot.starter.web[0;1m [auto][m
@@ -365,6 +369,8 @@ module Bibliothecary
 
         value = field.nodes.first
         value = value.value if value.is_a?(Ox::CData)
+        # whitespace in dependency tags should be ignored
+        value = value&.strip
         match = value&.match(MAVEN_PROPERTY_REGEX)
         if match
           return extract_property(xml, match[1], value, parent_properties)

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -254,7 +254,7 @@ module Bibliothecary
       end
 
       def self.parse_resolved_dep_line(line)
-        # filter out anythinmg that doesn't look like a
+        # filter out anything that doesn't look like a
         # resolved dep line
         return unless line[/  .*:[^-]+-- /]
 

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.7.1"
+  VERSION = "8.7.2"
 end

--- a/spec/fixtures/pom-spaces-in-artifact-and-group.xml
+++ b/spec/fixtures/pom-spaces-in-artifact-and-group.xml
@@ -1,0 +1,241 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- Doesn't work on previous versions because of Eclipse/Sonatype Aether incompatibility. -->
+  <prerequisites>
+    <maven>3.1</maven>
+  </prerequisites>
+
+  <groupId>com.versioneye</groupId>
+  <artifactId>versioneye-maven-plugin</artifactId>
+  <version>3.10.0</version>
+  <packaging>maven-plugin</packaging>
+
+  <name>versioneye-maven-plugin</name>
+  <url>https://github.com/versioneye/versioneye_maven_plugin</url>
+  <description>
+    This is the maven plugin for http://www.VersionEye.com. It allows you to create and update
+    a project at VersionEye. You can find a complete documentation of this project on GitHub:
+    https://github.com/versioneye/versioneye_maven_plugin.
+  </description>
+
+  <scm>
+    <connection>scm:git:https://github.com/versioneye/versioneye_maven_plugin.git</connection>
+    <developerConnection>scm:git:https://github.com/versioneye/versioneye_maven_plugin.git</developerConnection>
+    <url>https://github.com/versioneye/versioneye_maven_plugin.git</url>
+  </scm>
+
+  <licenses>
+    <license>
+      <name>MIT</name>
+      <url>http://choosealicense.com/licenses/mit/</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Robert Reiz</name>
+      <id>reiz</id>
+      <organization>VersionEye</organization>
+      <organizationUrl>https://www.VersionEye.com</organizationUrl>
+    </developer>
+  </developers>
+
+  <distributionManagement>
+      <downloadUrl>http://repo1.maven.org/maven2/com/versioneye/versioneye-maven-plugin</downloadUrl>
+      <repository>
+          <id>ossrh</id>
+          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      </repository>
+  </distributionManagement>
+
+  <properties>
+    <!-- The minimum Maven version that should be supported. -->
+    <maven.version>3.3.9</maven.version>
+    <jackson.version>1.9.13</jackson.version>
+    <httpcomponents.version>4.5.2</httpcomponents.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId> org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>${maven.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven </groupId>
+      <artifactId>maven-core</artifactId>
+      <version>${maven.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId> maven-plugin-annotations</artifactId>
+      <version>3.4</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-core-lgpl </artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-mapper-lgpl</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>${httpcomponents.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpmime</artifactId>
+      <version>${httpcomponents.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>6.9.12</version>
+      <scope>test</scope>
+    </dependency>
+    <!--<dependency>-->
+      <!--<groupId>io.reactivex</groupId>-->
+      <!--<artifactId>rxjava</artifactId>-->
+      <!--<version>[1.1.0,)</version>-->
+    <!--</dependency>-->
+  </dependencies>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>com.versioneye</groupId>
+        <artifactId>versioneye-maven-plugin</artifactId>
+        <version>3.10.0</version>
+        <configuration>
+          <!--<apiKey>YOUR_API_KEY</apiKey> --> <!-- To find here: https://www.versioneye.com/settings/api -->
+          <!--<baseUrl>http://localhost:3000</baseUrl>-->
+          <!--<proxyHost>127.0.0.1</proxyHost>-->
+          <!--<proxyPort>8888</proxyPort>-->
+          <!--<proxyUser>proxy_hopsi</proxyUser>-->
+          <!--<proxyPassword>dont_tell_anybody</proxyPassword>-->
+          <!--<updatePropertiesAfterCreate>false</updatePropertiesAfterCreate>-->
+          <!--<mergeAfterCreate>false</mergeAfterCreate>--> <!-- This is only for multi module projects! -->
+          <!--<parentGroupId>com.versioneye</parentGroupId>-->
+          <!--<parentArtifactId>versioneye-maven-plugin</parentArtifactId>-->
+          <!--<nameStrategy>GA</nameStrategy>--> <!-- Default value is 'name'. Other options are 'GA' and 'artifact_id'. -->
+          <!--<skipScopes>test</skipScopes>-->
+          <!--<organisation>versioneye</organisation>-->
+          <!--<name>NameOfTheProjectAtVersionEye</name>-->
+          <!--<visibility>TrueOrFalse</visibility>-->
+          <transitiveDependencies>false</transitiveDependencies>
+        </configuration>
+      </plugin>
+
+      <!--http://central.sonatype.org/pages/apache-maven.html-->
+      <!--mvn clean deploy -Dgpg.passphrase=-->
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.7</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+
+
+      <!-- mvn gpg:sign -->
+      <!-- mvn gpg:sign-and-deploy-file -->
+      <!-- mvn clean deploy -Dgpg.passphrase=my_secret_passphrase -->
+      <!-- mvn clean install -Dgpg.passphrase=my_secret_passphrase -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <executions>
+            <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                    <goal>sign</goal>
+                </goals>
+            </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>3.4</version>
+        <configuration>
+          <goalPrefix>versioneye</goalPrefix>
+          <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+        </configuration>
+        <executions>
+          <execution>
+            <id>mojo-descriptor</id>
+            <goals>
+              <goal>descriptor</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>help-goal</id>
+            <goals>
+              <goal>helpmojo</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.0.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+  </build>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-changelog-plugin</artifactId>
+        <version>2.3</version>
+        <configuration>
+          <type>tag</type>
+          <tags>
+            <tag implementation="java.lang.String">3.5.1</tag>
+            <tag implementation="java.lang.String">3.6.0</tag>
+          </tags>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+
+</project>

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -139,6 +139,39 @@ RSpec.describe Bibliothecary::Parsers::Maven do
     })
   end
 
+  it 'parses dependencies from pom-spaces-in-artifact-and-group.xml' do
+    expect(described_class.analyse_contents('pom.xml', load_fixture('pom-spaces-in-artifact-and-group.xml'))).to eq({
+      platform: "maven",
+      path: "pom.xml",
+      dependencies: [
+        { name: "org.apache.maven:maven-plugin-api",
+          requirement: "3.3.9",
+          type: "runtime" },
+         { name: "org.apache.maven:maven-core",
+          requirement: "3.3.9",
+          type: "runtime" },
+         { name: "org.apache.maven.plugin-tools:maven-plugin-annotations",
+          requirement: "3.4",
+          type: "provided" },
+         { name: "org.codehaus.jackson:jackson-core-lgpl",
+          requirement: "1.9.13",
+          type: "runtime" },
+         { name: "org.codehaus.jackson:jackson-mapper-lgpl",
+          requirement: "1.9.13",
+          type: "runtime" },
+         { name: "org.apache.httpcomponents:httpclient",
+          requirement: "4.5.2",
+          type: "runtime" },
+         { name: "org.apache.httpcomponents:httpmime",
+          requirement: "4.5.2",
+          type: "runtime" },
+         { name: "org.testng:testng", requirement: "6.9.12", type: "test" }
+      ],
+      kind: 'manifest',
+      success: true
+    })
+  end
+
   it 'parses dependencies from ivy.xml' do
     expect(described_class.analyse_contents('ivy.xml', load_fixture('ivy.xml'))).to eq({
       platform: "maven",
@@ -376,13 +409,19 @@ RSpec.describe Bibliothecary::Parsers::Maven do
     expect(testng_dep[:requirement]).to eq("${missing_property}")
   end
 
-  it 'parses dependencies from maven-dependencies-q.txt' do
+  it 'parses dependencies from maven-resolved-dependencies.txt' do
     deps = described_class.analyse_contents('maven-resolved-dependencies.txt', load_fixture('maven-resolved-dependencies.txt'))
     expect(deps[:kind]).to eq 'lockfile'
     spring_boot = deps[:dependencies].select {|item| item[:name] == "org.springframework.boot:spring-boot-starter-web" }
     expect(spring_boot.length).to eq 1
     expect(spring_boot.first[:requirement]).to eq '2.0.3.RELEASE'
     expect(spring_boot.first[:type]).to eq 'compile'
+  end
+
+  it 'correctly ignores dependencies if a maven-resolved-dependencies file contains the content of a maven-dependency-tree file' do
+    deps = described_class.analyse_contents('maven-resolved-dependencies.txt', load_fixture('maven-dependency-tree.txt'))
+    expect(deps[:kind]).to eq 'lockfile'
+    expect(deps[:dependencies]).to eq([])
   end
 
   it 'parses dependencies from sbt-update-full.txt' do


### PR DESCRIPTION
* Strip whitespace inside `artifactId` and `groupId` tags in pom.xml files
* Be more aggressive with the lines we allow in `maven-resolved-dependencies.txt` to ensure only lines that match that format are returned as dependencies