### PR TITLE
Bibliothecary::FileParsingError: add error location to error message

### DIFF
--- a/lib/bibliothecary/analyser/analysis.rb
+++ b/lib/bibliothecary/analyser/analysis.rb
@@ -84,7 +84,10 @@ module Bibliothecary
 
       rescue Exception => e # default is StandardError but C bindings throw Exceptions
         # the C xml parser also puts a newline at the end of the message
-        raise Bibliothecary::FileParsingError.new(e.message.strip, filename)
+        location = e.backtrace_locations[0]
+          .to_s
+          .then { |l| l =~ /bibliothecary\// ? l.split("bibliothecary/").last : l.split("gems/").last }
+        raise Bibliothecary::FileParsingError.new("#{e.message.strip} (#{location})", filename)
       end
 
       private

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -306,26 +306,26 @@ RSpec.describe Bibliothecary::Parsers::Maven do
       dependencies: nil,
       kind: 'lockfile',
       success: false,
-      error_message: "missing_info.xml: ivy-report document lacks <info> element"
+      error_message: "missing_info.xml: ivy-report document lacks <info> element (parsers/maven.rb:134:in `parse_ivy_report')"
     })
   end
 
   it 'raises FileParsingError on a broken ivy report' do
     expect {
       described_class.parse_file('missing_info.xml', load_fixture('ivy_reports/missing_info.xml'))
-    }.to raise_error(Bibliothecary::FileParsingError, "missing_info.xml: ivy-report document lacks <info> element")
+    }.to raise_error(Bibliothecary::FileParsingError, "missing_info.xml: ivy-report document lacks <info> element (parsers/maven.rb:134:in `parse_ivy_report')")
   end
 
   it 'raises FileParsingError on an xml file with no ivy_report' do
     expect {
       described_class.parse_file('non_ivy_report.xml', load_fixture('ivy_reports/non_ivy_report.xml'))
-    }.to raise_error(Bibliothecary::FileParsingError, "non_ivy_report.xml: No parser for this file type")
+    }.to raise_error(Bibliothecary::FileParsingError, "non_ivy_report.xml: No parser for this file type (analyser/analysis.rb:76:in `parse_file')")
   end
 
   it 'returns [] on an .xml file with bad syntax' do
     expect {
       described_class.parse_file('invalid_syntax.xml', load_fixture('ivy_reports/invalid_syntax.xml'))
-    }.to raise_error(Bibliothecary::FileParsingError, "invalid_syntax.xml: No parser for this file type")
+    }.to raise_error(Bibliothecary::FileParsingError, "invalid_syntax.xml: No parser for this file type (analyser/analysis.rb:76:in `parse_file')")
   end
 
   it 'cannot determine kind on an ivy report with no contents specified' do

--- a/spec/parsers/npm_spec.rb
+++ b/spec/parsers/npm_spec.rb
@@ -152,7 +152,7 @@ describe Bibliothecary::Parsers::NPM do
       dependencies: nil,
       kind: 'manifest',
       success: false,
-      error_message: "package.json: appears to be a lockfile rather than manifest format"
+      error_message: "package.json: appears to be a lockfile rather than manifest format (parsers/npm.rb:97:in `parse_manifest')"
     })
   end
 


### PR DESCRIPTION
### Example

#### Before:
`pyproject.toml: no implicit conversion of Hash into Array`

#### After:
`pyproject.toml: no implicit conversion of Hash into Array (parsers/pypi.rb:109:in `+')`