### PR TITLE
8.7.4: Add support for Poetry 1.2.0+'s dependency groups

### DIFF
--- a/lib/bibliothecary/parsers/pypi.rb
+++ b/lib/bibliothecary/parsers/pypi.rb
@@ -101,8 +101,16 @@ module Bibliothecary
 
         # Parse poetry [tool.poetry] deps
         poetry_manifest = file_contents.fetch('tool', {}).fetch('poetry', {})
+        # Poetry 1.0.0-1.2.0 way of defining dev deps
         deps += map_dependencies(poetry_manifest['dependencies'], 'runtime')
-        deps += map_dependencies(poetry_manifest['dev-dependencies'], 'develop')
+        deps += map_dependencies(poetry_manifest['dev-dependencies'], 'development')
+        # Poetry's 1.2.0+ of defining dev deps
+        poetry_manifest
+          .fetch("group", {})
+          .each_pair do |group_name, obj|
+            group_name = "development" if group_name == "dev"
+            deps += map_dependencies(obj.fetch("dependencies", {}), group_name)
+          end
 
         # Parse PEP621 [project] deps
         pep621_manifest = file_contents.fetch('project', {})

--- a/lib/bibliothecary/parsers/pypi.rb
+++ b/lib/bibliothecary/parsers/pypi.rb
@@ -101,14 +101,14 @@ module Bibliothecary
 
         # Parse poetry [tool.poetry] deps
         poetry_manifest = file_contents.fetch('tool', {}).fetch('poetry', {})
-        # Poetry 1.0.0-1.2.0 way of defining dev deps
         deps += map_dependencies(poetry_manifest['dependencies'], 'runtime')
-        deps += map_dependencies(poetry_manifest['dev-dependencies'], 'development')
+        # Poetry 1.0.0-1.2.0 way of defining dev deps
+        deps += map_dependencies(poetry_manifest['dev-dependencies'], 'develop')
         # Poetry's 1.2.0+ of defining dev deps
         poetry_manifest
           .fetch("group", {})
           .each_pair do |group_name, obj|
-            group_name = "development" if group_name == "dev"
+            group_name = "develop" if group_name == "dev"
             deps += map_dependencies(obj.fetch("dependencies", {}), group_name)
           end
 
@@ -187,10 +187,10 @@ module Bibliothecary
         manifest["package"].each do |package|
           # next if group == "_meta"
           group = case package['category']
-                  when 'main'
-                    'runtime'
                   when 'dev'
                     'develop'
+                  else
+                    'runtime'
                   end
 
           deps << {

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.7.3"
+  VERSION = "8.7.4"
 end

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.7.2"
+  VERSION = "8.7.3"
 end

--- a/spec/fixtures/pyproject.toml
+++ b/spec/fixtures/pyproject.toml
@@ -8,13 +8,16 @@ authors = ["Tyrel Souza <tyrel@tidelift.com>"]
 python = "^3.7"
 django = "^3.0.7"
 
-# Old way to define dev deps (<1.2.0)
+# Old way to define development deps (<1.2.0)
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"
 
-# New way to define dev deps (>=1.2.0)
+# New way to define development deps (>=1.2.0)
 [tool.poetry.group.dev.dependencies]
 wcwidth = "*"
+
+[tool.poetry.group.test.dependencies]
+sqlparse = "0.3.1"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/spec/fixtures/pyproject.toml
+++ b/spec/fixtures/pyproject.toml
@@ -8,11 +8,11 @@ authors = ["Tyrel Souza <tyrel@tidelift.com>"]
 python = "^3.7"
 django = "^3.0.7"
 
-# Old way to defining dev deps (<1.2.0)
+# Old way to define dev deps (<1.2.0)
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"
 
-# New way to defining dev deps (>=1.2.0)
+# New way to define dev deps (>=1.2.0)
 [tool.poetry.group.dev.dependencies]
 wcwidth = "*"
 

--- a/spec/fixtures/pyproject.toml
+++ b/spec/fixtures/pyproject.toml
@@ -8,8 +8,13 @@ authors = ["Tyrel Souza <tyrel@tidelift.com>"]
 python = "^3.7"
 django = "^3.0.7"
 
+# Old way to defining dev deps (<1.2.0)
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"
+
+# New way to defining dev deps (>=1.2.0)
+[tool.poetry.group.dev.dependencies]
+wcwidth = "*"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/spec/parsers/pypi_spec.rb
+++ b/spec/parsers/pypi_spec.rb
@@ -287,7 +287,8 @@ git://what@::/:/:/
       dependencies: [
         { name: "python", requirement: "^3.7", type: "runtime" },
         { name: "django", requirement: "^3.0.7", type: "runtime" },
-        { name: "pytest", requirement: "^5.2", type: "develop" }
+        { name: "pytest", requirement: "^5.2", type: "development" },
+        { name: "wcwidth", requirement: "*", type: "development" },
       ],
       kind: 'manifest',
       success: true

--- a/spec/parsers/pypi_spec.rb
+++ b/spec/parsers/pypi_spec.rb
@@ -287,8 +287,8 @@ git://what@::/:/:/
       dependencies: [
         { name: "python", requirement: "^3.7", type: "runtime" },
         { name: "django", requirement: "^3.0.7", type: "runtime" },
-        { name: "pytest", requirement: "^5.2", type: "development" },
-        { name: "wcwidth", requirement: "*", type: "development" },
+        { name: "pytest", requirement: "^5.2", type: "develop" },
+        { name: "wcwidth", requirement: "*", type: "develop" },
       ],
       kind: 'manifest',
       success: true

--- a/spec/parsers/pypi_spec.rb
+++ b/spec/parsers/pypi_spec.rb
@@ -289,6 +289,7 @@ git://what@::/:/:/
         { name: "django", requirement: "^3.0.7", type: "runtime" },
         { name: "pytest", requirement: "^5.2", type: "develop" },
         { name: "wcwidth", requirement: "*", type: "develop" },
+        { name: "sqlparse", requirement: "0.3.1", type: "test" },
       ],
       kind: 'manifest',
       success: true


### PR DESCRIPTION
Poetry 1.2.0 added support for dependency groups in https://github.com/python-poetry/poetry/pull/4260 , e.g.:

```
[tool.poetry.group.test.dependencies]
pytest = "^6.0.0"
pytest-mock = "*"
```

docs: https://github.com/python-poetry/poetry/blob/1.7.1/docs/managing-dependencies.md#dependency-groups
