### PR TITLE
8.7.5: go.mod: adds official support for "replace" directive

### DIFF
--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.7.4"
+  VERSION = "8.7.5"
 end

--- a/spec/fixtures/go.mod
+++ b/spec/fixtures/go.mod
@@ -2,6 +2,8 @@ module mod
 
 go 1.12
 
+// this is a comment line
+
 require (
   github.com/go-check/check v0.0.0-20180628173108-788fd7840127 // indirect
   github.com/gomodule/redigo v2.0.0+incompatible // indirect
@@ -10,15 +12,15 @@ require (
   gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0
 )
 
-require golang.org/x/net v1.2.3
+require golang.org/x/net v1.2.3 // this is the single-line require directive
 
-exclude old/thing 1.2.3
+exclude old/thing 1.2.3 // this is the single-line exclude directive
 
 exclude (
-  older/thing 4.5.6
+  older/thing 4.5.6 // this is the multi-line exclude directive
 )
 
-replace bad/thing v1.4.5 => good/thing v1.4.5
+replace bad/thing v1.4.5 => good/thing v1.4.5 // this is the single-line exclude directive
 
 replace (
     golang.org/x/net v1.2.3 => example.com/fork/net v1.4.5
@@ -27,11 +29,11 @@ replace (
     golang.org/x/net => ./fork/net
 )
 
-retract v1.0.0
+retract v1.0.0 // this is the single-line retract directive
 
 retract [v2.0.0, v1.9.9]
 
 retract (
-    v1.0.0
+    v1.0.0  // this is the multi-line retract directive
     [v1.0.0, v1.9.9]
 )

--- a/spec/fixtures/go.mod
+++ b/spec/fixtures/go.mod
@@ -9,5 +9,29 @@ require (
   github.com/replicon/fast-archiver v0.0.0-20121220195659-060bf9adec25 // indirect
   gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0
 )
+
+require golang.org/x/net v1.2.3
+
 exclude old/thing 1.2.3
+
+exclude (
+  older/thing 4.5.6
+)
+
 replace bad/thing v1.4.5 => good/thing v1.4.5
+
+replace (
+    golang.org/x/net v1.2.3 => example.com/fork/net v1.4.5
+    golang.org/x/net => example.com/fork/net v1.4.5
+    golang.org/x/net v1.2.3 => ./fork/net
+    golang.org/x/net => ./fork/net
+)
+
+retract v1.0.0
+
+retract [v2.0.0, v1.9.9]
+
+retract (
+    v1.0.0
+    [v1.0.0, v1.9.9]
+)

--- a/spec/parsers/go_spec.rb
+++ b/spec/parsers/go_spec.rb
@@ -8,29 +8,42 @@ describe Bibliothecary::Parsers::Go do
   it_behaves_like "CycloneDX"
 
   it "parses depenencies from go.mod" do
-    expect(described_class.analyse_contents("go.mod", load_fixture("go.mod"))).to eq({
-      platform: "go",
-      path: "go.mod",
-      dependencies: [
-        { name: "github.com/go-check/check",
-         requirement: "v0.0.0-20180628173108-788fd7840127",
-         type: "runtime" },
-        { name: "github.com/gomodule/redigo",
-         requirement: "v2.0.0+incompatible",
-         type: "runtime" },
-        { name: "github.com/kr/pretty",
-         requirement: "v0.1.0",
-         type: "runtime" },
-        { name: "github.com/replicon/fast-archiver",
-         requirement: "v0.0.0-20121220195659-060bf9adec25",
-         type: "runtime" },
-        { name: "gopkg.in/yaml.v1",
-         requirement: "v1.0.0-20140924161607-9f9df34309c0",
-         type: "runtime" },
-      ],
-      kind: "manifest",
-      success: true,
-    })
+    expect(described_class.analyse_contents("go.mod", load_fixture("go.mod"))).to eq({:platform=>"go",
+    path: "go.mod",
+    dependencies: [
+      {
+        name: "github.com/go-check/check",
+        requirement: "v0.0.0-20180628173108-788fd7840127",
+        type: "runtime",
+      },
+      {
+        name: "github.com/gomodule/redigo",
+        requirement: "v2.0.0+incompatible",
+        type: "runtime",
+      },
+      {
+        name: "github.com/kr/pretty", 
+        requirement: "v0.1.0", 
+        type: "runtime",
+      },
+      { name: "github.com/replicon/fast-archiver",
+        requirement: "v0.0.0-20121220195659-060bf9adec25",
+        type: "runtime",
+      },
+      {
+        name: "gopkg.in/yaml.v1",
+        requirement: "v1.0.0-20140924161607-9f9df34309c0",
+        type: "runtime"},
+      {
+        original_name: "golang.org/x/net", 
+        original_requirement: "v1.2.3", 
+        name: "example.com/fork/net", 
+        requirement: "v1.4.5", 
+        type: "runtime",
+      },
+    ],
+    kind: "manifest",
+    success: true})
   end
 
   it "parses depenencies from go.mod with a single require" do


### PR DESCRIPTION
this should fix the `replace` parsing bugs, where we currently get `{name: "foo -> bar", ...}` back for deps:

* adds parsing support for all go.mod directives: `require`, `replace`, `extract`, and `retract`
* uses `replace` results to replace any matching deps in `require` results
* ignore `exclude` results for now, since they're not related to `require` results

