### PR TITLE
Standardize on _REGEXP names over _REGEX

### DIFF
--- a/lib/bibliothecary/multi_parsers/spdx.rb
+++ b/lib/bibliothecary/multi_parsers/spdx.rb
@@ -12,16 +12,16 @@ module Bibliothecary
       include Bibliothecary::Analyser::TryCache
 
       # e.g. 'SomeText:' (allowing for leading whitespace)
-      WELLFORMED_LINE_REGEX = /^\s*[a-zA-Z]+:/
+      WELLFORMED_LINE_REGEXP = /^\s*[a-zA-Z]+:/
 
       # e.g. 'PackageName: (allowing for excessive whitespace)
-      PACKAGE_NAME_REGEX = /^\s*PackageName:\s*(.*)/
+      PACKAGE_NAME_REGEXP = /^\s*PackageName:\s*(.*)/
 
       # e.g. 'PackageVersion:' (allowing for excessive whitespace)
-      PACKAGE_VERSION_REGEX =/^\s*PackageVersion:\s*(.*)/
+      PACKAGE_VERSION_REGEXP =/^\s*PackageVersion:\s*(.*)/
 
       # e.g. "ExternalRef: PACKAGE-MANAGER purl (allowing for excessive whitespace)
-      PURL_REGEX = /^\s*ExternalRef:\s*PACKAGE[-|_]MANAGER\s*purl\s*(.*)/
+      PURL_REGEXP = /^\s*ExternalRef:\s*PACKAGE[-|_]MANAGER\s*purl\s*(.*)/
 
       NoEntries = Class.new(StandardError)
       MalformedFile = Class.new(StandardError)
@@ -64,13 +64,13 @@ module Bibliothecary
 
           next if skip_line?(stripped_line)
 
-          raise MalformedFile unless stripped_line.match(WELLFORMED_LINE_REGEX)
+          raise MalformedFile unless stripped_line.match(WELLFORMED_LINE_REGEXP)
 
-          if (match = stripped_line.match(PACKAGE_NAME_REGEX))
+          if (match = stripped_line.match(PACKAGE_NAME_REGEXP))
             package_name = match[1]
-          elsif (match = stripped_line.match(PACKAGE_VERSION_REGEX))
+          elsif (match = stripped_line.match(PACKAGE_VERSION_REGEXP))
             package_version = match[1]
-          elsif (match = stripped_line.match(PURL_REGEX))
+          elsif (match = stripped_line.match(PURL_REGEXP))
             platform ||= get_platform(match[1])
           end
 

--- a/lib/bibliothecary/parsers/pypi.rb
+++ b/lib/bibliothecary/parsers/pypi.rb
@@ -15,7 +15,7 @@ module Bibliothecary
       PIP_COMPILE_REGEXP = /.*require.*$/
 
       # Adapted from https://peps.python.org/pep-0508/#names
-      PEP_508_NAME_REGEX = /^([A-Z0-9][A-Z0-9._-]*[A-Z0-9]|[A-Z0-9])/i
+      PEP_508_NAME_REGEXP = /^([A-Z0-9][A-Z0-9._-]*[A-Z0-9]|[A-Z0-9])/i
 
       def self.mapping
         {
@@ -289,7 +289,7 @@ module Bibliothecary
       # Simply parses out the name of a PEP 508 Dependency specification: https://peps.python.org/pep-0508/
       # Leaves the rest as-is with any leading semicolons or spaces stripped
       def self.parse_pep_508_dep_spec(dep)
-        name, requirement = dep.split(PEP_508_NAME_REGEX, 2).last(2).map(&:strip)
+        name, requirement = dep.split(PEP_508_NAME_REGEXP, 2).last(2).map(&:strip)
         requirement = requirement.sub(/^[\s;]*/, "")
         requirement = "*" if requirement == ""
         return name, requirement


### PR DESCRIPTION
small style change: we should use `_REGEXP` as a suffix for constants instead of `_REGEX` so that the code is consistent and because Ruby's regular expression class is called `Regexp`.

(I considered keeping the old constants as deprecated constants and removing them in a later major version, but since we don't keep a CHANGELOG and we don't really do big major version releases, the result will be the same: downstream users will just be alerted that a constant they use is missing and they'll have to refer to the gem)