### PR TITLE
Add a note about how the go.mod parser deviates from go commands.

### DIFF
--- a/lib/bibliothecary/parsers/go.rb
+++ b/lib/bibliothecary/parsers/go.rb
@@ -129,8 +129,12 @@ module Bibliothecary
 
         deps = categorized_deps["require"]
           .map do |dep|
-            # A "replace" directive doesn't add the dep to the module graph unless the original dep is also in a "require" directive,
+            # NOTE: A "replace" directive doesn't add the dep to the module graph unless the original dep is also in a "require" directive,
             # so we need to track down replacements here and use those instead of the originals, if present.
+            #
+            # NOTE: The "replace" directive doesn't actually change the version reported from Go (e.g. "go mod graph"), it only changes
+            # the *source code*. So by replacing the deps here, we're giving more honest results than you'd get when asking go
+            # about the versions used.
             replaced_dep = categorized_deps["replace"]
               .find do |replacement_dep| 
                 replacement_dep[:original_name] == dep[:name] && 


### PR DESCRIPTION
we discovered today that the `"replace"` directive only replaces the source code and doesn't actually replace the version reported (e.g. https://github.com/golang/go/issues/40513#issuecomment-667328207), so this adds a note about how bibliothecary results might differ from go's.