### PR TITLE
8.7.6:  go-resolved-dependencies.json: adds official support for "replace" directive 

### DIFF
--- a/lib/bibliothecary/parsers/go.rb
+++ b/lib/bibliothecary/parsers/go.rb
@@ -188,7 +188,7 @@ module Bibliothecary
         JSON.parse(file_contents)
           .select { |dep| dep["Main"] != "true" }
           .map do |dep| 
-            if dep["Replace"] != "<nil>" && dep["Replace"] != ""
+            if dep["Replace"].is_a?(String) && dep["Replace"] != "<nil>" && dep["Replace"] != ""
               # NOTE: The "replace" directive doesn't actually change the version reported from Go (e.g. "go mod graph"), it only changes
               # the *source code*. So by replacing the deps here, we're giving more honest results than you'd get when asking go
               # about the versions used.

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.7.5"
+  VERSION = "8.7.6"
 end

--- a/spec/fixtures/go-resolved-dependencies.json
+++ b/spec/fixtures/go-resolved-dependencies.json
@@ -3,104 +3,133 @@
       "Main": "true",
       "Version": "",
       "Indirect": "false",
-      "Scope": "runtime"
+      "Scope": "runtime",
+      "Replace": "<nil>"
     },
     {
       "Path": "cloud.google.com/go",
       "Main": "false",
       "Version": "v0.36.0",
       "Indirect": "true",
-      "Scope": "runtime"
+      "Scope": "runtime",
+      "Replace": "<nil>"
     },
     {
       "Path": "dmitri.shuralyov.com/app/changes",
       "Main": "false",
       "Version": "v0.0.0-20180602232624-0a106ad413e3",
       "Indirect": "true",
-      "Scope": "runtime"
+      "Scope": "runtime",
+      "Replace": "<nil>"
     },
     {
       "Path": "dmitri.shuralyov.com/html/belt",
       "Main": "false",
       "Version": "v0.0.0-20180602232347-f7d459c86be0",
       "Indirect": "true",
-      "Scope": "runtime"
+      "Scope": "runtime",
+      "Replace": "<nil>"
     },
     {
       "Path": "dmitri.shuralyov.com/service/change",
       "Main": "false",
       "Version": "v0.0.0-20181023043359-a85b471d5412",
       "Indirect": "true",
-      "Scope": "runtime"
+      "Scope": "runtime",
+      "Replace": "<nil>"
     },
     {
       "Path": "dmitri.shuralyov.com/state",
       "Main": "false",
       "Version": "v0.0.0-20180228185332-28bcc343414c",
       "Indirect": "true",
-      "Scope": "runtime"
+      "Scope": "runtime",
+      "Replace": "<nil>"
     },
     {
       "Path": "git.apache.org/thrift.git",
       "Main": "false",
       "Version": "v0.0.0-20180902110319-2566ecd5d999",
       "Indirect": "true",
-      "Scope": "runtime"
+      "Scope": "runtime",
+      "Replace": "<nil>"
     },
     {
       "Path": "github.com/BurntSushi/toml",
       "Main": "false",
       "Version": "v0.3.1",
       "Indirect": "true",
-      "Scope": "runtime"
+      "Scope": "runtime",
+      "Replace": "<nil>"
     },
     {
       "Path": "github.com/Masterminds/semver",
       "Main": "false",
       "Version": "v1.5.0",
       "Indirect": "true",
-      "Scope": "runtime"
+      "Scope": "runtime",
+      "Replace": "<nil>"
     },
     {
       "Path": "github.com/Masterminds/semver/v3",
       "Main": "false",
       "Version": "v3.0.3",
       "Indirect": "true",
-      "Scope": "runtime"
+      "Scope": "runtime",
+      "Replace": "<nil>"
     },
     {
       "Path": "github.com/OneOfOne/xxhash",
       "Main": "false",
       "Version": "v1.2.2",
       "Indirect": "true",
-      "Scope": "runtime"
+      "Scope": "runtime",
+      "Replace": "<nil>"
     },
     {
       "Path": "github.com/ajg/form",
       "Main": "false",
       "Version": "v1.5.1",
       "Indirect": "true",
-      "Scope": "runtime"
+      "Scope": "runtime",
+      "Replace": "<nil>"
     },
     {
       "Path": "github.com/alecthomas/template",
       "Main": "false",
       "Version": "v0.0.0-20160405071501-a0175ee3bccc",
       "Indirect": "true",
-      "Scope": "runtime"
+      "Scope": "runtime",
+      "Replace": "<nil>"
     },
     {
       "Path": "github.com/alecthomas/units",
       "Main": "false",
       "Version": "v0.0.0-20151022065526-2efee857e7cf",
       "Indirect": "true",
-      "Scope": "runtime"
+      "Scope": "runtime",
+      "Replace": "<nil>"
     },
     {
       "Path": "github.com/stretchr/testify",
       "Main": "false",
       "Version": "v1.7.0",
       "Indirect": "false",
-      "Scope": "test"
+      "Scope": "test",
+      "Replace": "<nil>"
+    },
+    {
+      "Path": "golang.org/x/net", 
+      "Main": "false", 
+      "Version": "v1.2.3", 
+      "Indirect": "false", 
+      "Replace": "example.com/fork/net v1.4.5"
+    },
+    {
+      "Path": "bad/thing", 
+      "Main": "false", 
+      "Version": "v1.4.5", 
+      "Indirect": "false", 
+      "Replace": "./some/local/path"
     }
   ]

--- a/spec/fixtures/go-resolved-dependencies.json
+++ b/spec/fixtures/go-resolved-dependencies.json
@@ -115,8 +115,7 @@
       "Main": "false",
       "Version": "v1.7.0",
       "Indirect": "false",
-      "Scope": "test",
-      "Replace": "<nil>"
+      "Scope": "test"
     },
     {
       "Path": "golang.org/x/net", 

--- a/spec/parsers/go_spec.rb
+++ b/spec/parsers/go_spec.rb
@@ -296,6 +296,8 @@ describe Bibliothecary::Parsers::Go do
         { name: "github.com/alecthomas/template", requirement: "v0.0.0-20160405071501-a0175ee3bccc", type: "runtime" },
         { name: "github.com/alecthomas/units", requirement: "v0.0.0-20151022065526-2efee857e7cf", type: "runtime" },
         { name: "github.com/stretchr/testify", requirement: "v1.7.0", type: "test" },
+        { name: "example.com/fork/net", requirement: "v1.4.5", original_name: "golang.org/x/net", original_requirement: "v1.2.3", type: "runtime" },
+        { name: "./some/local/path", requirement: "*", original_name: "bad/thing", original_requirement: "v1.4.5", type: "runtime" },
       ],
       kind: "lockfile",
       success: true,


### PR DESCRIPTION
(followup to https://github.com/librariesio/bibliothecary/pull/585)

as we learned today, `"replace"` directives are not reported by things like `go mod graph`, and are only reported by `go list` if you ask for the ".Replace" directive, since `"replace"` only replaces the source code of the replaced version and not the actual version reported as used by go.

this adds support for the "Replace" field in `go-resolved-dependencies.json` files such that we can replace the deps during Bibliothecary analysis of those files, as we did in #585 with `go.mod` files.