### PR TITLE
Parse cyclonedx files named *.cdx.json or *.cdx.xml

### DIFF
--- a/lib/bibliothecary/multi_parsers/cyclonedx.rb
+++ b/lib/bibliothecary/multi_parsers/cyclonedx.rb
@@ -81,7 +81,17 @@ module Bibliothecary
             parser: :parse_cyclonedx_json,
             ungroupable: true,
           },
+          match_extension("cdx.json") => {
+            kind: "lockfile",
+            parser: :parse_cyclonedx_json,
+            ungroupable: true,
+          },
           match_filename("cyclonedx.xml") => {
+            kind: "lockfile",
+            parser: :parse_cyclonedx_xml,
+            ungroupable: true,
+          },
+          match_extension(".cdx.xml") => {
             kind: "lockfile",
             parser: :parse_cyclonedx_xml,
             ungroupable: true,


### PR DESCRIPTION
Based off of the suggested filename patterns in the spec and from the SBOM everywhere openssf WG