### PR TITLE
Bibliothecary.analyze(): skip analysis of binary files so we don't try to read invalid utf8

### DIFF
--- a/lib/bibliothecary/parsers/pypi.rb
+++ b/lib/bibliothecary/parsers/pypi.rb
@@ -12,6 +12,7 @@ module Bibliothecary
 
       REQUIREMENTS_REGEXP = /^#{REQUIRE_REGEXP}/
       MANIFEST_REGEXP = /.*require[^\/]*(\/)?[^\/]*\.(txt|pip|in)$/
+      # TODO: can this be a more specific regexp so it doesn't match something like ".yarn/cache/create-require-npm-1.0.0.zip"?
       PIP_COMPILE_REGEXP = /.*require.*$/
 
       # Adapted from https://peps.python.org/pep-0508/#names

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "8.7.6"
+  VERSION = "8.7.7"
 end

--- a/spec/bibliothecary_spec.rb
+++ b/spec/bibliothecary_spec.rb
@@ -88,6 +88,12 @@ describe Bibliothecary do
     expect(result[0][:dependencies].length).to eq(0)
   end
 
+  it "skips analysis of non-text files" do
+    result = described_class.analyse_file("some.zip", "\xC2")
+
+    expect(result).to eq([])
+  end
+
   it "aliases analyse and analyse_file" do
     expect(Bibliothecary.method(:analyse)).to eq(Bibliothecary.method(:analyze))
     expect(Bibliothecary.method(:analyse_file)).to eq(Bibliothecary.method(:analyze_file))


### PR DESCRIPTION
after forcing UTF-8 on all files before we read them in https://github.com/librariesio/bibliothecary/pull/565 , it was revealed that a pip-compile regexp we have is very generic and catching everything with `"require"` in the filename, which causes Bibliothecary.analyze() to blow up on binary files. 

This rescues the encoding error and skips analysis, although a better fix might be to detect binary files and skip reading them altogether (and to just fix that regexp so it's less generic).

closes https://github.com/librariesio/bibliothecary/issues/590

