### PR TITLE
Remove strings/strings-ansi gems in favor of copying their regexp.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,5 @@
 source "https://rubygems.org"
 
-# Temporarily pegging to HEAD until 0.2.1 is released: https://github.com/piotrmurach/strings-ansi/pull/2
-gem "strings-ansi", ref: "35d0c9430cf0a8022dc12bdab005bce296cb9f00", git: "git@github.com:piotrmurach/strings-ansi.git"
-
 # Specify your gem's dependencies in bibliothecary.gemspec
 gemspec
 

--- a/bibliothecary.gemspec
+++ b/bibliothecary.gemspec
@@ -25,8 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "deb_control"
   spec.add_dependency "sdl4r"
   spec.add_dependency "commander"
-  spec.add_dependency "strings-ansi" # NB this is also pegged to a git sha in Gemfile temporarily.  
-  spec.add_dependency "strings"
   spec.add_dependency "packageurl-ruby"
 
   spec.add_development_dependency "pry"

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "10.2.0"
+  VERSION = "10.2.1"
 end

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -312,7 +312,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
       kind: "lockfile",
       success: false,
       error_message: "missing_info.xml: ivy-report document lacks <info> element",
-      error_location: "parsers/maven.rb:134:in `parse_ivy_report'",
+      error_location: "parsers/maven.rb:154:in `parse_ivy_report'",
     })
   end
 


### PR DESCRIPTION
bibliothecary uses `strings` and `strings-ansi` to strip ANSI escape codes from Maven lockfiles.

the gem [seems unmaintained](https://github.com/piotrmurach/strings-ansi/pull/2), so this removes the gem in favor of using its regex directly (and giving it credit).