### PR TITLE
Fix using parent props for deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [10.2.4] - 2024-11-06
+
+### Changed
+
+- Fixed parsing of pom files where parent properties within the file are required for dependencies
+
 ## [10.2.2] - 2024-09-25
 
 ### Added

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -425,7 +425,6 @@ module Bibliothecary
         # the xml root is <project> so lookup the non property name in the xml
         # this converts ${project/group.id} -> ${group/id}
         non_prop_name = property_name.gsub(".", "/").gsub("project/", "")
-        return "${#{property_name}}" if !xml.respond_to?("properties") && parent_properties.empty? && xml.locate(non_prop_name).empty?
 
         prop_field = xml.properties.locate(property_name).first if xml.respond_to?("properties")
         parent_prop = parent_properties[property_name] ||                 # e.g. "${foo}"

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "10.2.3"
+  VERSION = "10.2.4"
 end

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -392,6 +392,15 @@ RSpec.describe Bibliothecary::Parsers::Maven do
       expect(bibliothecary_dep.requirement).to eq("9.9.9")
     end
 
+    it "uses parent properties from pom file for groupid" do
+      deps = described_class.parse_pom_manifest(load_fixture("pom_no_props.xml"))
+
+      # this is referenced as ${parent.groupId} for the groupId in the pom file but we
+      # can use from the parent
+      dep_with_propertied_parent = deps.find { |dep| dep.name == "org.accidia:echo-parent"}
+      expect(dep_with_propertied_parent.requirement).to eq ("0.1.23")
+    end
+
     it "can extract parent properties specified with a lookup prefix during resolve" do
       parent_props = { "scm.url"=>"scm:git:git@github.com:accidia/echo.git" }
 


### PR DESCRIPTION
 Refactoring of this was returning too early and not using any parent properties that are specified in the pom file.

property_value now returns nil for cases where it can't find the value and extract_property is properly using the fallback value in that case rather than requiring an interpolation of what it should have been