### PR TITLE
fix: [sc-46631] Libraries is returning wrong requirements for maven packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+
+## [11.0.1] - 2024-12-20
+
+### Changed
+
+- Alow retrieving maven versions from parent poms
+
 ## [11.0.0] - 2024-11-22
 
 ### Changed

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -297,45 +297,73 @@ module Bibliothecary
       # parent_properties is used by Libraries:
       # https://github.com/librariesio/libraries.io/blob/e970925aade2596a03268b6e1be785eba8502c62/app/models/package_manager/maven.rb#L129
       def self.parse_pom_manifest(file_contents, parent_properties = {}, options: {}) # rubocop:disable Lint/UnusedMethodArgument
-        manifest = Ox.parse file_contents
-        xml = manifest.respond_to?("project") ? manifest.project : manifest
-        [].tap do |deps|
-          # <dependencyManagement> is a namespace to specify artifact configuration (e.g. version), but it doesn't
-          # actually add dependencies to your project. Grab these and keep them for reference while parsing <dependencies>
-          # Ref: https://maven.apache.org/pom.html#Dependency_Management
-          # Ref: https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#transitive-dependencies
-          dependencyManagement = xml.locate("dependencyManagement/dependencies/dependency").map do |dep|
-            {
-              groupId: extract_pom_dep_info(xml, dep, "groupId", parent_properties),
-              artifactId: extract_pom_dep_info(xml, dep, "artifactId", parent_properties),
-              version: extract_pom_dep_info(xml, dep, "version", parent_properties),
-              scope: extract_pom_dep_info(xml, dep, "scope", parent_properties),
-            }
-          end
-          # <dependencies> is the namespace that will add dependencies to your project.
-          xml.locate("dependencies/dependency").each do |dep|
-            groupId = extract_pom_dep_info(xml, dep, "groupId", parent_properties)
-            artifactId = extract_pom_dep_info(xml, dep, "artifactId", parent_properties)
-            version = extract_pom_dep_info(xml, dep, "version", parent_properties)
-            scope = extract_pom_dep_info(xml, dep, "scope", parent_properties)
+        parse_pom_manifests([file_contents], parent_properties)
+      end
 
-            # Use any dep configurations from <dependencyManagement> as fallbacks
-            if (depConfig = dependencyManagement.find { |d| d[:groupId] == groupId && d[:artifactId] == artifactId })
-              version ||= depConfig[:version]
-              scope ||= depConfig[:scope]
+      # @param files [Array<String>] Ordered array of strings containing the
+      # pom.xml bodies. The first element should be the child file.
+      # @param merged_properties [Hash]
+      def self.parse_pom_manifests(files, merged_properties)
+        documents = files.map do |file|
+          doc = Ox.parse(file)
+          doc.respond_to?("project") ? doc.project : doc
+        end
+
+        mergedDependencyManagements = {}
+        documents.each do |document|
+           document.locate("dependencyManagement/dependencies/dependency").each do |dep|
+              groupId = extract_pom_dep_info(document, dep, "groupId", merged_properties)
+              artifactId = extract_pom_dep_info(document, dep, "artifactId", merged_properties)
+              key = "#{groupId}:#{artifactId}"
+              mergedDependencyManagements[key] ||=
+                {
+                  groupId: groupId,
+                  artifactId: artifactId,
+                  version: extract_pom_dep_info(document, dep, "version", merged_properties),
+                  scope: extract_pom_dep_info(document, dep, "scope", merged_properties),
+                }
+           end
+        end
+
+        dep_hashes = {}
+        documents.each do |document|
+          document.locate("dependencies/dependency").each do |dep|
+            groupId = extract_pom_dep_info(document, dep, "groupId", merged_properties)
+            artifactId = extract_pom_dep_info(document, dep, "artifactId", merged_properties)
+            key = "#{groupId}:#{artifactId}"
+            unless dep_hashes.key?(key)
+              dep_hashes[key] = {
+                name: key,
+                requirement: nil,
+                type: nil,
+                optional: nil,
+              }
             end
+            dep_hash = dep_hashes[key]
 
-            dep_hash = {
-              name: "#{groupId}:#{artifactId}",
-              requirement: version,
-              type: scope || "runtime",
-            }
+            dep_hash[:requirement] ||= extract_pom_dep_info(document, dep, "version", merged_properties)
+            dep_hash[:type] ||= extract_pom_dep_info(document, dep, "scope", merged_properties)
+
             # optional field is, itself, optional, and will be either "true" or "false"
-            optional = extract_pom_dep_info(xml, dep, "optional", parent_properties)
-            dep_hash[:optional] = optional == "true" unless optional.nil?
-            deps.push(Dependency.new(**dep_hash))
+            optional = extract_pom_dep_info(document, dep, "optional", merged_properties)
+            if dep_hash[:optional].nil? && !optional.nil?
+              dep_hash[:optional] = optional == "true"
+            end
           end
         end
+
+        # Anything that wasn't covered by a dependency version, get from the
+        # dependencyManagements
+        dep_hashes.each do |key, dep_hash|
+          if (dependencyManagement = mergedDependencyManagements[key])
+            dep_hash[:requirement] ||= dependencyManagement[:version]
+            dep_hash[:type] ||= dependencyManagement[:scope]
+          end
+
+          dep_hash[:type] ||= "runtime"
+        end
+
+        dep_hashes.map{|key, dep_hash| Dependency.new(**dep_hash)}
       end
 
       def self.parse_gradle(file_contents, options: {}) # rubocop:disable Lint/UnusedMethodArgument

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -294,8 +294,6 @@ module Bibliothecary
         parse_pom_manifest(file_contents, {}, options: options)
       end
 
-      # parent_properties is used by Libraries:
-      # https://github.com/librariesio/libraries.io/blob/e970925aade2596a03268b6e1be785eba8502c62/app/models/package_manager/maven.rb#L129
       def self.parse_pom_manifest(file_contents, parent_properties = {}, options: {}) # rubocop:disable Lint/UnusedMethodArgument
         parse_pom_manifests([file_contents], parent_properties)
       end

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,3 +1,3 @@
 module Bibliothecary
-  VERSION = "11.0.0"
+  VERSION = "11.0.1"
 end

--- a/spec/fixtures/maven_parent_deps/jaxb-bom-2.3.1.pom.xml
+++ b/spec/fixtures/maven_parent_deps/jaxb-bom-2.3.1.pom.xml
@@ -1,0 +1,253 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2013-2018 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://oss.oracle.com/licenses/CDDL+GPL-1.1
+    or LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.java</groupId>
+        <artifactId>jvnet-parent</artifactId>
+        <version>5</version>
+    </parent>
+
+    <groupId>org.glassfish.jaxb</groupId>
+    <artifactId>jaxb-bom</artifactId>
+    <version>2.3.1</version>
+
+    <packaging>pom</packaging>
+    <name>JAXB BOM</name>
+    <description>JAXB Bill of Materials (BOM)</description>
+
+    <properties>
+        <jaxb-api.version>2.3.1</jaxb-api.version>
+        <jaxb-api-osgi.version>2.3</jaxb-api-osgi.version>
+        <istack.version>3.0.7</istack.version>
+        <fastinfoset.version>1.2.15</fastinfoset.version>
+        <stax-ex.version>1.8</stax-ex.version>
+        <dtd-parser.version>1.4</dtd-parser.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- *** SOURCES *** -->
+            <!-- new -->
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>${project.version}</version>
+                <classifier>sources</classifier>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-xjc</artifactId>
+                <version>${project.version}</version>
+                <classifier>sources</classifier>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-jxc</artifactId>
+                <version>${project.version}</version>
+                <classifier>sources</classifier>
+            </dependency>
+
+            <!--OLD-->
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>${project.version}</version>
+                <classifier>sources</classifier>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-xjc</artifactId>
+                <version>${project.version}</version>
+                <classifier>sources</classifier>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-jxc</artifactId>
+                <version>${project.version}</version>
+                <classifier>sources</classifier>
+            </dependency>
+
+            <dependency> <!--JAXB-API-->
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb-api.version}</version>
+                <classifier>sources</classifier>
+            </dependency>
+            <dependency>
+                <groupId>org.jvnet.staxex</groupId>
+                <artifactId>stax-ex</artifactId>
+                <version>${stax-ex.version}</version>
+                <classifier>sources</classifier>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.fastinfoset</groupId>
+                <artifactId>FastInfoset</artifactId>
+                <version>${fastinfoset.version}</version>
+                <classifier>sources</classifier>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.dtd-parser</groupId>
+                <artifactId>dtd-parser</artifactId>
+                <version>${dtd-parser.version}</version>
+            </dependency>
+
+
+            <!-- *** BINARIES *** -->
+            <!-- new -->
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-xjc</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-jxc</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!--OLD-->
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-xjc</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-jxc</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!-- OSGI -->
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-osgi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!-- Dependencies -->
+
+            <dependency> <!--JAXB-API-->
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.istack</groupId>
+                <artifactId>istack-commons-runtime</artifactId>
+                <version>${istack.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.fastinfoset</groupId>
+                <artifactId>FastInfoset</artifactId>
+                <version>${fastinfoset.version}</version>
+                <exclusions>
+                    <!-- part of JDK 6+ -->
+                    <exclusion>
+                        <artifactId>jsr173_api</artifactId>
+                        <groupId>javax.xml.bind</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.jvnet.staxex</groupId>
+                <artifactId>stax-ex</artifactId>
+                <version>${stax-ex.version}</version>
+                <exclusions>
+                    <!-- part of JDK 6+ -->
+                    <exclusion>
+                        <groupId>javax.activation</groupId>
+                        <artifactId>activation</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>stax-api</artifactId>
+                        <groupId>javax.xml.stream</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>javax.activation</groupId>
+                <artifactId>javax.activation-api</artifactId>
+                <version>1.2.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.0.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>1.6</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.2</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/spec/fixtures/maven_parent_deps/jaxb-runtime-2.3.1.pom.xml
+++ b/spec/fixtures/maven_parent_deps/jaxb-runtime-2.3.1.pom.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2013-2018 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://oss.oracle.com/licenses/CDDL+GPL-1.1
+    or LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.sun.xml.bind.mvn</groupId>
+        <artifactId>jaxb-runtime-parent</artifactId>
+        <version>2.3.1</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.glassfish.jaxb</groupId>
+    <artifactId>jaxb-runtime</artifactId>
+
+    <packaging>jar</packaging>
+    <name>JAXB Runtime</name>
+    <description>JAXB (JSR 222) Reference Implementation</description>
+
+    <properties>
+        <findbugs.exclude>${project.basedir}/exclude-runtime.xml</findbugs.exclude>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>txw2</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.istack</groupId>
+            <artifactId>istack-commons-runtime</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jvnet.staxex</groupId>
+            <artifactId>stax-ex</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.fastinfoset</groupId>
+            <artifactId>FastInfoset</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>javax.activation-api</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <workingDirectory>target/test-out</workingDirectory>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-module-path</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${module.path}</outputDirectory>
+                            <silent>false</silent>
+                            <includeArtifactIds>txw2,istack-commons-runtime,stax-ex,FastInfoset</includeArtifactIds>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>prepare-upgrade-module-path</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${module.path}/api</outputDirectory>
+                            <silent>false</silent>
+                            <includeArtifactIds>jaxb-api</includeArtifactIds>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <release>${upper.java.level}</release>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>base-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>${base.java.level}</release>
+                            <excludes>
+                                <exclude>module-info.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalJOptions>
+                        <additionalJOption>--add-modules</additionalJOption>
+                        <additionalJOption>java.activation</additionalJOption>
+                        <additionalJOption>--module-path</additionalJOption>
+                        <additionalJOption>${module.path}</additionalJOption>
+                    </additionalJOptions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Story details: https://app.shortcut.com/tidelift/story/46631

Add a new method which accepts an ordered array of pom xml strings ordered from child to parent. This allows Bibliothecary to parse more complex versioning scenarios such as a parent pom containing a versioned `dependency` element or a `dependencyManagement` element.