### PR TITLE
12.1.1: add a regression spec for "go tool" deps to go.mod test fixture

### DIFF
--- a/lib/bibliothecary/parsers/cargo.rb
+++ b/lib/bibliothecary/parsers/cargo.rb
@@ -48,7 +48,7 @@ module Bibliothecary
       def self.parse_lockfile(file_contents, options: {})
         manifest = Tomlrb.parse(file_contents)
         manifest.fetch("package", []).map do |dependency|
-          next if !(dependency["source"]) || !dependency["source"].start_with?("registry+")
+          next if !dependency["source"] || !dependency["source"].start_with?("registry+")
 
           Dependency.new(
             name: dependency["name"],

--- a/lib/bibliothecary/runner.rb
+++ b/lib/bibliothecary/runner.rb
@@ -138,7 +138,8 @@ module Bibliothecary
       end
       allowed_file_list = allowed_file_list.reject { |f| ignored_files.include?(f) }
       package_managers.map do |pm|
-        allowed_file_list.select do |file_path| # rubocop:disable  Style/SelectByRegexp (this is a rubocop false positive, match? is a custom method)
+        # (skip rubocop false positive, since match? is a custom method)
+        allowed_file_list.select do |file_path| # rubocop:disable Style/SelectByRegexp
           # this is a call to match? without file contents, which will skip
           # ambiguous filenames that are only possibly a manifest
           pm.match?(file_path)

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bibliothecary
-  VERSION = "12.1.0"
+  VERSION = "12.1.1"
 end

--- a/spec/fixtures/go.mod
+++ b/spec/fixtures/go.mod
@@ -1,12 +1,16 @@
 module mod
 
-go 1.12
+go 1.24
+
+toolchain go1.24.0
 
 // this is a comment line
 
 require (
   github.com/go-check/check v0.0.0-20180628173108-788fd7840127 // indirect
   github.com/gomodule/redigo v2.0.0+incompatible // indirect
+  github.com/jstemmer/go-junit-report v1.0.0 // indirect
+  github.com/jstemmer/go-junit-report/v2 v2.1.0 // indirect
   github.com/kr/pretty v0.1.0 // indirect
   github.com/replicon/fast-archiver v0.0.0-20121220195659-060bf9adec25 // indirect
   gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0
@@ -23,10 +27,10 @@ exclude (
 replace bad/thing v1.4.5 => good/thing v1.4.5 // this is the single-line exclude directive
 
 replace (
-    golang.org/x/net v1.2.3 => example.com/fork/net v1.4.5
-    golang.org/x/net => example.com/fork/net v1.4.5
-    golang.org/x/net v1.2.3 => ./fork/net
-    golang.org/x/net => ./fork/net
+  golang.org/x/net v1.2.3 => example.com/fork/net v1.4.5
+  golang.org/x/net => example.com/fork/net v1.4.5
+  golang.org/x/net v1.2.3 => ./fork/net
+  golang.org/x/net => ./fork/net
 )
 
 retract v1.0.0 // this is the single-line retract directive
@@ -34,6 +38,13 @@ retract v1.0.0 // this is the single-line retract directive
 retract [v2.0.0, v1.9.9]
 
 retract (
-    v1.0.0  // this is the multi-line retract directive
-    [v1.0.0, v1.9.9]
+  v1.0.0  // this is the multi-line retract directive
+  [v1.0.0, v1.9.9]
+)
+
+tool golang.org/x/tools/cmd/stringer
+
+tool (
+  github.com/jstemmer/go-junit-report
+  github.com/jstemmer/go-junit-report/v2
 )

--- a/spec/parsers/go_spec.rb
+++ b/spec/parsers/go_spec.rb
@@ -12,6 +12,8 @@ describe Bibliothecary::Parsers::Go do
   it "parses depenencies from go.mod" do
     expect(described_class.analyse_contents("go.mod", load_fixture("go.mod"))).to eq({ platform: "go",
                                                                                        path: "go.mod",
+                                                                                       kind: "manifest",
+                                                                                       success: true,
                                                                                        dependencies: [
       Bibliothecary::Dependency.new(
         name: "github.com/go-check/check",
@@ -23,6 +25,20 @@ describe Bibliothecary::Parsers::Go do
       Bibliothecary::Dependency.new(
         name: "github.com/gomodule/redigo",
         requirement: "v2.0.0+incompatible",
+        type: "runtime",
+        direct: false,
+        source: "go.mod"
+      ),
+      Bibliothecary::Dependency.new(
+        name: "github.com/jstemmer/go-junit-report",
+        requirement: "v1.0.0",
+        type: "runtime",
+        direct: false,
+        source: "go.mod"
+      ),
+      Bibliothecary::Dependency.new(
+        name: "github.com/jstemmer/go-junit-report/v2",
+        requirement: "v2.1.0",
         type: "runtime",
         direct: false,
         source: "go.mod"
@@ -57,9 +73,7 @@ describe Bibliothecary::Parsers::Go do
         direct: true,
         source: "go.mod"
       ),
-    ],
-                                                                                       kind: "manifest",
-                                                                                       success: true })
+    ] })
   end
 
   it "parses depenencies from go.mod with a single require" do


### PR DESCRIPTION
The [new `go tool` command](https://tip.golang.org/doc/go1.24#tools) adds a new stanza to the bottom of `go.mod`, but we don't need it and it doesn't have version information. This PR just adds the stanza to our test fixture to ensure it gets parsed as a no-op.

If it's not from the stdlib, then the tool and its dependencies will get added as indirect deps to `go.mod` (it'd be nicer if it was `// tool` or something like that instead of `// indirect`).