### PR TITLE
Constrain pypi file regex

### DIFF
--- a/lib/bibliothecary/parsers/pypi.rb
+++ b/lib/bibliothecary/parsers/pypi.rb
@@ -13,7 +13,7 @@ module Bibliothecary
       REQUIRE_REGEXP = /([a-zA-Z0-9]+[a-zA-Z0-9\-_\.]+)(?:\[.*?\])*([><=\w\.,]+)?/
       REQUIREMENTS_REGEXP = /^#{REQUIRE_REGEXP}/
 
-      MANIFEST_REGEXP = /.*require[^\/]*(\/)?[^\/]*\.(txt|pip|in)$/
+      MANIFEST_REGEXP = /.*require[^\/]*\.(txt|pip|in)$/
       # TODO: can this be a more specific regexp so it doesn't match something like ".yarn/cache/create-require-npm-1.0.0.zip"?
       PIP_COMPILE_REGEXP = /.*require.*$/
 

--- a/spec/parsers/pypi_spec.rb
+++ b/spec/parsers/pypi_spec.rb
@@ -405,6 +405,7 @@ describe Bibliothecary::Parsers::Pypi do
   it "fails to match invalid manifest filepaths" do
     expect(described_class.match?("some-random-file.txt")).to be_falsey
     expect(described_class.match?("require/some/other/folder/myhomework.txt")).to be_falsey
+    expect(described_class.match?("private/required-for-plugin/gradle-dependencies-q.txt")).to be_falsey
   end
 
   it "parses dependencies from pyproject.toml" do


### PR DESCRIPTION
Don't match any .txt file under a directory with `require` in it.