### PR TITLE
NPM: add workaround for bun.lock's trailing commas, in case Oj.mimic_json was invoked.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Use JSON.parser.parse() in bun.lock parser to work around overriden JSON.parse() method.
+
 ### Removed
 
 ## [12.1.5] - 2025-03-17

--- a/lib/bibliothecary/parsers/npm.rb
+++ b/lib/bibliothecary/parsers/npm.rb
@@ -395,7 +395,11 @@ module Bibliothecary
       end
 
       def self.parse_bun_lock(file_contents, options: {})
-        manifest = JSON.parse(file_contents, allow_trailing_comma: true)
+        # The stdlib JSON gem 2.8+ supports trailing commas.
+        # The Oj gem does not support them as of writing, and will override
+        # JSON.parse() if Oj.mimic_json/optimize_rails has been called. Luckily
+        # JSON.parser is not overridden by Oj, so use it to call parse directly.
+        manifest = JSON.parser.parse(file_contents, allow_trailing_comma: true)
         source = options.fetch(:filename, nil)
 
         dev_deps = manifest.dig("workspaces", "", "devDependencies")&.keys&.to_set


### PR DESCRIPTION
The [Oj gem has a mimic_json() method](https://github.com/ohler55/oj/blob/develop/ext/oj/mimic_json.c#L785-L830) that overrides most of the JSON gem's methods. It's difficult to detect this because it's a C extension so `JSON.method(:parse).source_location` won't show you the location. It also means that ":allow_trailing_commas" wouldn't work with Oj:

```
> JSON.parse("[1,2,3,]", allow_trailing_comma: true)
(irb):1:in `load': expected array element, not an array close (after ) at line 1, column 22 [parse.c:618] (Oj::ParseError)
        from (irb):1:in `<main>'
```

Luckily Oj did not override the JSON.parser() method, which returns an instance of the JSON parser. So use that directly to parse the JSON instead:

```
> JSON.parser.parse("[1,2,3,]", allow_trailing_comma: true)
=> [1, 2, 3]
```
