### PR TITLE
12.1.6: Don't raise an error if PNPM lockfile has no devDependencies section.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Removed
+
+## [12.1.6] - 2025-04-29
+
+### Added
+
+### Changed
+
 - Use JSON.parser.parse() in bun.lock parser to work around overriden JSON.parse() method.
+- Don't raise an error in pnpm-lock.yaml v9 parser if devDependencies isn't found.
 
 ### Removed
 

--- a/lib/bibliothecary/parsers/npm.rb
+++ b/lib/bibliothecary/parsers/npm.rb
@@ -324,8 +324,8 @@ module Bibliothecary
       end
 
       def self.parse_v9_pnpm_lock(parsed_contents, _source = nil)
-        dependencies = parsed_contents.fetch("importers", {}).fetch(".", {}).fetch("dependencies")
-        dev_dependencies = parsed_contents.fetch("importers", {}).fetch(".", {}).fetch("devDependencies")
+        dependencies = parsed_contents.fetch("importers", {}).fetch(".", {}).fetch("dependencies", {})
+        dev_dependencies = parsed_contents.fetch("importers", {}).fetch(".", {}).fetch("devDependencies", {})
         dependency_mapping = dependencies.merge(dev_dependencies)
 
         # "dependencies" is in "packages" for < v9 and in "snapshots" for >= v9

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bibliothecary
-  VERSION = "12.1.5"
+  VERSION = "12.1.6"
 end


### PR DESCRIPTION
It's possible that a `pnpm-lock.yaml` may not have a `devDependencies` section, so fall back to `{}` in those cases instead of raising an error. For example:

```
lockfileVersion: '9.0'

importers:

  .:
    dependencies:
      ansicolor:
        specifier: ^2.0.3
        version: 2.0.3

...
```