### PR TITLE
12.1.9: bugfix from 12.1.8 in poetry.lock parser.

### DIFF
--- a/lib/bibliothecary/parsers/pypi.rb
+++ b/lib/bibliothecary/parsers/pypi.rb
@@ -122,12 +122,6 @@ module Bibliothecary
         deps.uniq
       end
 
-      # TODO: this was deprecated in 8.6.0. Remove this in any major version bump >= 9.*
-      def self.parse_poetry(file_contents, options: {})
-        puts "Warning: parse_poetry() is deprecated, use parse_pyproject() instead."
-        parse_pyproject(file_contents, options)
-      end
-
       def self.parse_conda(file_contents, options: {})
         contents = YAML.safe_load(file_contents)
         return [] unless contents

--- a/lib/bibliothecary/parsers/pypi.rb
+++ b/lib/bibliothecary/parsers/pypi.rb
@@ -204,7 +204,7 @@ module Bibliothecary
 
           # Poetry <1.2.0 used singular "category" for kind
           # Poetry >=1.2.0 uses plural "groups" field for kind(s)
-          package.values_at("category", "groups").flatten.compact
+          groups = package.values_at("category", "groups").flatten.compact
             .map do |g|
               if g == "dev"
                 "develop"
@@ -212,14 +212,17 @@ module Bibliothecary
                 (g == "main" ? "runtime" : g)
               end
             end
-            .each do |group|
-              deps << Dependency.new(
-                name: package["name"],
-                requirement: map_requirements(package),
-                type: group,
-                source: options.fetch(:filename, nil)
-              )
-            end
+
+          groups = ["runtime"] if groups.empty?
+
+          groups.each do |group|
+            deps << Dependency.new(
+              name: package["name"],
+              requirement: map_requirements(package),
+              type: group,
+              source: options.fetch(:filename, nil)
+            )
+          end
         end
         deps
       end

--- a/spec/fixtures/poetry.lock
+++ b/spec/fixtures/poetry.lock
@@ -154,7 +154,8 @@ version = "0.13.1"
 description = "plugin and hook calling mechanisms for python"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-groups = ["dev"]
+# This line intentionally edited to test the case of no groups or categories
+# groups = ["dev"]
 files = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},

--- a/spec/parsers/pypi_spec.rb
+++ b/spec/parsers/pypi_spec.rb
@@ -487,7 +487,7 @@ describe Bibliothecary::Parsers::Pypi do
         Bibliothecary::Dependency.new(name: "more-itertools", requirement: "9.1.0", type: "develop", source: "poetry.lock"),
         Bibliothecary::Dependency.new(name: "packaging", requirement: "24.0", type: "develop", source: "poetry.lock"),
         Bibliothecary::Dependency.new(name: "pathlib2", requirement: "2.3.7.post1", type: "runtime", source: "poetry.lock"),
-        Bibliothecary::Dependency.new(name: "pluggy", requirement: "0.13.1", type: "develop", source: "poetry.lock"),
+        Bibliothecary::Dependency.new(name: "pluggy", requirement: "0.13.1", type: "runtime", source: "poetry.lock"),
         Bibliothecary::Dependency.new(name: "py", requirement: "1.11.0", type: "develop", source: "poetry.lock"),
         Bibliothecary::Dependency.new(name: "pytest", requirement: "5.4.3", type: "develop", source: "poetry.lock"),
         Bibliothecary::Dependency.new(name: "pytz", requirement: "2025.2", type: "runtime", source: "poetry.lock"),


### PR DESCRIPTION
(followup to https://github.com/librariesio/bibliothecary/pull/626)

It turns out some poetry.lock files -- maybe with older versions of Poetry? -- may contain deps without a category or group field.

