### PR TITLE
12.3.1: improve Nuget .csproj support by handling leading <?xml> tag 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [12.3.1] - 2025-06-06
+
+### Changed
+
+- Handle .csproj files that begin with an <?xml> tag
+
 ## [12.3.0] - 2025-06-06
 
 ### Added

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bibliothecary
-  VERSION = "12.3.0"
+  VERSION = "12.3.1"
 end

--- a/spec/parsers/nuget_spec.rb
+++ b/spec/parsers/nuget_spec.rb
@@ -597,6 +597,29 @@ describe Bibliothecary::Parsers::Nuget do
     ])
   end
 
+  it "parses dependencies from .csproj with an xml tag" do
+    source = <<~FILE
+      <?xml version="1.0" encoding="utf-8"?>
+      <Project Sdk="Microsoft.NET.Sdk.Web">
+        <ItemGroup>
+          <Reference Include="FluentCommandLineParser, Version=1.0.25.0, Culture=neutral, processorArchitecture=MSIL" />
+        </ItemGroup>
+      </Project>
+    FILE
+
+    result = described_class.analyse_contents("example-with-xml-tag.csproj", source)
+
+    expect(result[:platform]).to eq("nuget")
+    expect(result[:path]).to eq("example-with-xml-tag.csproj")
+    expect(result[:kind]).to eq("manifest")
+    expect(result[:success]).to eq(true)
+    expect(result[:error_message]).to eq(nil)
+    expect(result[:error_location]).to eq(nil)
+    expect(result[:dependencies]).to eq([
+      Bibliothecary::Dependency.new(name: "FluentCommandLineParser", requirement: "1.0.25.0", type: "runtime", source: "example-with-xml-tag.csproj"),
+    ])
+  end
+
   it "parses dependencies from example.nuspec" do
     expect(described_class.analyse_contents("example.nuspec", load_fixture("example.nuspec"))).to eq({
                                                                                                        platform: "nuget",


### PR DESCRIPTION
The [dotnet/samples](https://github.com/dotnet1) repo has *.csproj files [without <?xml> tag](https://github.com/dotnet/samples/blob/main/framework/wcf/Basic/Discovery/CustomFindCriteria/CS/Service/CalculatorService.csproj#L) and [with <?xml> tag](https://github.com/dotnet/samples/blob/main/framework/libraries/migrate-library/src/Car/Car.csproj#L1-L2). 

This change adds support for "with <?xml> tag" so that we can support both cases.