### PR TITLE
[13.1.0] Convert parsed Nuget requirements to SemVer-style requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [13.1.0] - 2025-06-23
+
+### Changed
+
+- Fix any parsed nuget requirements by translating them from Nuget requirements to unofficial SemVer requirements (i.e. basically NPM-style ranges).
+
 ## [13.0.0] - 2025-06-17
 
 ### Removed

--- a/lib/bibliothecary/parsers/nuget/nuget_requirement.rb
+++ b/lib/bibliothecary/parsers/nuget/nuget_requirement.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Bibliothecary
+  module Parsers
+    class Nuget
+      class NugetRequirement
+        # Regular expressions for different NuGet version range patterns
+        MINOR_WILDCARD_REGEXP = /^(\d+)\.\*$/                         # 1.* - minor wildcard
+        PATCH_WILDCARD_REGEXP = /^(\d+)\.(\d+)\.\*$/                  # 1.2.* - patch wildcard
+        FULL_WILDCARD_REGEXP = /^\*$/                                 # * - full wildcard
+        MINIMUM_VERSION_REGEXP = /^\d+\.\d+.*$/                       # Minimum version like "1.0"
+        INCLUSIVE_LOWER_BOUND_REGEXP = /^\[([^,\]]+),\)$/             # [1.0,) - inclusive lower bound, no upper
+        EXCLUSIVE_LOWER_BOUND_REGEXP = /^\(([^,\]]+),\)$/             # (1.0,) - exclusive lower bound, no upper
+        EXACT_VERSION_REGEXP = /^\[([^,\]]+)\]$/                      # [1.0] - exact version
+        INCLUSIVE_UPPER_BOUND_REGEXP = /^\(,([^,\]]+)\]$/             # (,1.0] - no lower, inclusive upper bound
+        EXCLUSIVE_UPPER_BOUND_REGEXP = /^\(,([^,\]]+)\)$/             # (,1.0) - no lower, exclusive upper bound
+        INCLUSIVE_RANGE_REGEXP = /^\[([^,\]]+),([^,\]]+)\]$/          # [1.0,2.0] - inclusive range
+        EXCLUSIVE_RANGE_REGEXP = /^\(([^,\]]+),([^,\]]+)\)$/          # (1.0,2.0) - exclusive range
+        INCLUSIVE_LOWER_EXCLUSIVE_UPPER_REGEXP = /^\[([^,\]]+),([^,\]]+)\)$/ # [1.0,2.0) - inclusive lower, exclusive upper
+        EXCLUSIVE_LOWER_INCLUSIVE_UPPER_REGEXP = /^\(([^,\]]+),([^,\]]+)\]$/ # (1.0,2.0] - exclusive lower, inclusive upper
+
+        # Converts NuGet version range syntax to a semver requirement syntax
+        # supported by the semantic_range gem (https://github.com/librariesio/semantic_range).
+        # Nuget docs: https://learn.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges
+        #
+        # @param requirement [String] The NuGet version range string
+        # @return [String] The converted semver requirement string
+        # @raise [ArgumentError] If the requirement format is invalid
+        def self.convert_to_semver_requirement(requirement)
+          case requirement
+          when MINOR_WILDCARD_REGEXP
+            "~> #{::Regexp.last_match(1)}.0"
+          when PATCH_WILDCARD_REGEXP
+            ">= #{::Regexp.last_match(1)}.0"
+          when FULL_WILDCARD_REGEXP, nil
+            ">= 0"
+          when MINIMUM_VERSION_REGEXP
+            ">= #{requirement}"
+          when INCLUSIVE_LOWER_BOUND_REGEXP
+            ">= #{::Regexp.last_match(1)}"
+          when EXCLUSIVE_LOWER_BOUND_REGEXP
+            "> #{::Regexp.last_match(1)}"
+          when EXACT_VERSION_REGEXP
+            ::Regexp.last_match(1)
+          when INCLUSIVE_UPPER_BOUND_REGEXP
+            "<= #{::Regexp.last_match(1)}"
+          when EXCLUSIVE_UPPER_BOUND_REGEXP
+            "< #{::Regexp.last_match(1)}"
+          when INCLUSIVE_RANGE_REGEXP
+            ">= #{::Regexp.last_match(1)} <= #{::Regexp.last_match(2)}"
+          when EXCLUSIVE_RANGE_REGEXP
+            "> #{::Regexp.last_match(1)} < #{::Regexp.last_match(2)}"
+          when INCLUSIVE_LOWER_EXCLUSIVE_UPPER_REGEXP
+            ">= #{::Regexp.last_match(1)} < #{::Regexp.last_match(2)}"
+          when EXCLUSIVE_LOWER_INCLUSIVE_UPPER_REGEXP
+            "> #{::Regexp.last_match(1)} <= #{::Regexp.last_match(2)}"
+          else
+            raise ArgumentError, "Invalid NuGet version range format: #{requirement}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bibliothecary
-  VERSION = "13.0.0"
+  VERSION = "13.1.0"
 end

--- a/spec/parsers/nuget/nuget_requirement_spec.rb
+++ b/spec/parsers/nuget/nuget_requirement_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Bibliothecary::Parsers::Nuget::NugetRequirement do
+  describe "#convert_to_semver_requirement" do
+    it "converts simple version to >= constraint" do
+      expect(described_class.convert_to_semver_requirement("1.0")).to eq(">= 1.0")
+      expect(described_class.convert_to_semver_requirement("1.2.3-alpha.0.beta")).to eq(">= 1.2.3-alpha.0.beta")
+    end
+
+    it "converts inclusive lower bound range to >= constraint" do
+      expect(described_class.convert_to_semver_requirement("[1.0,)")).to eq(">= 1.0")
+      expect(described_class.convert_to_semver_requirement("[1.2.3-alpha.0.beta,)")).to eq(">= 1.2.3-alpha.0.beta")
+    end
+
+    it "converts exclusive lower bound range to > constraint" do
+      expect(described_class.convert_to_semver_requirement("(1.0,)")).to eq("> 1.0")
+      expect(described_class.convert_to_semver_requirement("(1.2.3-alpha.0.beta,)")).to eq("> 1.2.3-alpha.0.beta")
+    end
+
+    it "converts exact version range to exact constraint" do
+      expect(described_class.convert_to_semver_requirement("[1.0]")).to eq("1.0")
+      expect(described_class.convert_to_semver_requirement("[1.2.3-alpha.0.beta]")).to eq("1.2.3-alpha.0.beta")
+    end
+
+    it "converts inclusive upper bound range to <= constraint" do
+      expect(described_class.convert_to_semver_requirement("(,1.0]")).to eq("<= 1.0")
+      expect(described_class.convert_to_semver_requirement("(,1.2.3-alpha.0.beta]")).to eq("<= 1.2.3-alpha.0.beta")
+    end
+
+    it "converts exclusive upper bound range to < constraint" do
+      expect(described_class.convert_to_semver_requirement("(,1.0)")).to eq("< 1.0")
+      expect(described_class.convert_to_semver_requirement("(,1.2.3-alpha.0.beta)")).to eq("< 1.2.3-alpha.0.beta")
+    end
+
+    it "converts inclusive range to >= <= constraints" do
+      expect(described_class.convert_to_semver_requirement("[1.0,2.0]")).to eq(">= 1.0 <= 2.0")
+      expect(described_class.convert_to_semver_requirement("[1.2.3-alpha.0.beta,2.4.5-rc.1]")).to eq(">= 1.2.3-alpha.0.beta <= 2.4.5-rc.1")
+    end
+
+    it "converts exclusive range to > < constraints" do
+      expect(described_class.convert_to_semver_requirement("(1.0,2.0)")).to eq("> 1.0 < 2.0")
+      expect(described_class.convert_to_semver_requirement("(1.2.3-alpha.0.beta,2.4.5-rc.1)")).to eq("> 1.2.3-alpha.0.beta < 2.4.5-rc.1")
+    end
+
+    it "converts inclusive lower, exclusive upper range to >= < constraints" do
+      expect(described_class.convert_to_semver_requirement("[1.0,2.0)")).to eq(">= 1.0 < 2.0")
+      expect(described_class.convert_to_semver_requirement("[1.2.3-alpha.0.beta,2.4.5-rc.1)")).to eq(">= 1.2.3-alpha.0.beta < 2.4.5-rc.1")
+    end
+
+    it "converts exclusive lower, inclusive upper range to > <= constraints" do
+      expect(described_class.convert_to_semver_requirement("(1.0,2.0]")).to eq("> 1.0 <= 2.0")
+      expect(described_class.convert_to_semver_requirement("(1.2.3-alpha.0.beta,2.4.5-rc.1]")).to eq("> 1.2.3-alpha.0.beta <= 2.4.5-rc.1")
+    end
+
+    it "raises an error for invalid range format" do
+      expect { described_class.convert_to_semver_requirement("(1.0)") }.to raise_error(ArgumentError)
+      expect { described_class.convert_to_semver_requirement("(1.2.3-alpha.0.beta)") }.to raise_error(ArgumentError)
+    end
+
+    it "converts wildcard version to ~> constraint" do
+      expect(described_class.convert_to_semver_requirement("1.*")).to eq("~> 1.0")
+    end
+
+    it "converts patch wildcard version to >= constraint" do
+      # In node semver ranges, this would evaluate to "~> 1.2.0 <1.3.0", but
+      # a manual test with a csproj requirement for "Newtonsoft.Json" of "4.7.*"
+      # when no 4.7 line exists results in a resolved version of "5.0.1".
+      expect(described_class.convert_to_semver_requirement("1.2.*")).to eq(">= 1.0")
+    end
+
+    it "converts full wildcard to >= 0 constraint" do
+      expect(described_class.convert_to_semver_requirement("*")).to eq(">= 0")
+    end
+
+    it "converts nil to wildcard" do
+      expect(described_class.convert_to_semver_requirement(nil)).to eq(">= 0")
+    end
+  end
+end

--- a/spec/parsers/nuget_spec.rb
+++ b/spec/parsers/nuget_spec.rb
@@ -505,13 +505,13 @@ describe Bibliothecary::Parsers::Nuget do
                                                                                                          platform: "nuget",
                                                                                                          path: "packages.config",
                                                                                                          dependencies: [
-        Bibliothecary::Dependency.new(name: "AutoMapper", requirement: "2.1.267", type: "runtime", source: "packages.config"),
-        Bibliothecary::Dependency.new(name: "Microsoft.Web.Infrastructure", requirement: "1.0.0.0", type: "runtime", source: "packages.config"),
-        Bibliothecary::Dependency.new(name: "Mvc3Futures", requirement: "3.0.20105.0", type: "runtime", source: "packages.config"),
-        Bibliothecary::Dependency.new(name: "Ninject", requirement: "3.0.1.10", type: "runtime", source: "packages.config"),
-        Bibliothecary::Dependency.new(name: "Ninject.Web.Common", requirement: "3.0.0.7", type: "runtime", source: "packages.config"),
-        Bibliothecary::Dependency.new(name: "WebActivator", requirement: "1.5", type: "runtime", source: "packages.config"),
-        Bibliothecary::Dependency.new(name: "Microsoft.Net.Compilers", requirement: "1.0.0", type: "development", source: "packages.config"),
+        Bibliothecary::Dependency.new(name: "AutoMapper", requirement: ">= 2.1.267", type: "runtime", source: "packages.config"),
+        Bibliothecary::Dependency.new(name: "Microsoft.Web.Infrastructure", requirement: ">= 1.0.0.0", type: "runtime", source: "packages.config"),
+        Bibliothecary::Dependency.new(name: "Mvc3Futures", requirement: ">= 3.0.20105.0", type: "runtime", source: "packages.config"),
+        Bibliothecary::Dependency.new(name: "Ninject", requirement: ">= 3.0.1.10", type: "runtime", source: "packages.config"),
+        Bibliothecary::Dependency.new(name: "Ninject.Web.Common", requirement: ">= 3.0.0.7", type: "runtime", source: "packages.config"),
+        Bibliothecary::Dependency.new(name: "WebActivator", requirement: ">= 1.5", type: "runtime", source: "packages.config"),
+        Bibliothecary::Dependency.new(name: "Microsoft.Net.Compilers", requirement: ">= 1.0.0", type: "development", source: "packages.config"),
       ],
                                                                                                          kind: "manifest",
                                                                                                          success: true,
@@ -523,14 +523,14 @@ describe Bibliothecary::Parsers::Nuget do
                                                                                                        platform: "nuget",
                                                                                                        path: "example.csproj",
                                                                                                        dependencies: [
-        Bibliothecary::Dependency.new(name: "Microsoft.AspNetCore", requirement: "1.1.1", type: "runtime", source: "example.csproj"),
-        Bibliothecary::Dependency.new(name: "Microsoft.AspNetCore.Mvc", requirement: "1.1.2", type: "runtime", source: "example.csproj"),
-        Bibliothecary::Dependency.new(name: "Microsoft.AspNetCore.StaticFiles", requirement: "1.1.1", type: "runtime", source: "example.csproj"),
-        Bibliothecary::Dependency.new(name: "Microsoft.Extensions.Logging.Debug", requirement: "1.1.1", type: "runtime", source: "example.csproj"),
-        Bibliothecary::Dependency.new(name: "Microsoft.Extensions.DependencyInjection", requirement: "1.1.1", type: "runtime", source: "example.csproj"),
-        Bibliothecary::Dependency.new(name: "Microsoft.VisualStudio.Web.BrowserLink", requirement: "1.1.0", type: "runtime", source: "example.csproj"),
-        Bibliothecary::Dependency.new(name: "System.Resources.Extensions", requirement: "4.7.0", type: "runtime", source: "example.csproj"),
-        Bibliothecary::Dependency.new(name: "Contoso.Utility.UsefulStuff", requirement: "3.6.0", type: "development", source: "example.csproj"),
+        Bibliothecary::Dependency.new(name: "Microsoft.AspNetCore", requirement: ">= 1.1.1", type: "runtime", source: "example.csproj"),
+        Bibliothecary::Dependency.new(name: "Microsoft.AspNetCore.Mvc", requirement: ">= 1.1.2", type: "runtime", source: "example.csproj"),
+        Bibliothecary::Dependency.new(name: "Microsoft.AspNetCore.StaticFiles", requirement: ">= 1.1.1", type: "runtime", source: "example.csproj"),
+        Bibliothecary::Dependency.new(name: "Microsoft.Extensions.Logging.Debug", requirement: ">= 1.1.1", type: "runtime", source: "example.csproj"),
+        Bibliothecary::Dependency.new(name: "Microsoft.Extensions.DependencyInjection", requirement: ">= 1.1.1", type: "runtime", source: "example.csproj"),
+        Bibliothecary::Dependency.new(name: "Microsoft.VisualStudio.Web.BrowserLink", requirement: ">= 1.1.0", type: "runtime", source: "example.csproj"),
+        Bibliothecary::Dependency.new(name: "System.Resources.Extensions", requirement: ">= 4.7.0", type: "runtime", source: "example.csproj"),
+        Bibliothecary::Dependency.new(name: "Contoso.Utility.UsefulStuff", requirement: ">= 3.6.0", type: "development", source: "example.csproj"),
       ],
                                                                                                        kind: "manifest",
                                                                                                        success: true,
@@ -542,8 +542,8 @@ describe Bibliothecary::Parsers::Nuget do
                                                                                                                   platform: "nuget",
                                                                                                                   path: "example.csproj",
                                                                                                                   dependencies: [
-        Bibliothecary::Dependency.new(name: "Microsoft.AspNetCore.App", requirement: "*", type: "runtime", source: "example.csproj"),
-        Bibliothecary::Dependency.new(name: "Microsoft.AspNetCore.Razor.Design", requirement: "2.2.0", type: "development", source: "example.csproj"),
+        Bibliothecary::Dependency.new(name: "Microsoft.AspNetCore.App", requirement: ">= 0", type: "runtime", source: "example.csproj"),
+        Bibliothecary::Dependency.new(name: "Microsoft.AspNetCore.Razor.Design", requirement: ">= 2.2.0", type: "development", source: "example.csproj"),
       ],
                                                                                                                   kind: "manifest",
                                                                                                                   success: true,
@@ -555,8 +555,8 @@ describe Bibliothecary::Parsers::Nuget do
                                                                                                                      platform: "nuget",
                                                                                                                      path: "example-update.csproj",
                                                                                                                      dependencies: [
-        Bibliothecary::Dependency.new(name: "Microsoft.AspNetCore", requirement: "1.1.1", type: "runtime", source: "example-update.csproj"),
-        Bibliothecary::Dependency.new(name: "Microsoft.AspNetCore.StaticFiles", requirement: "2.2.0", type: "runtime", source: "example-update.csproj"),
+        Bibliothecary::Dependency.new(name: "Microsoft.AspNetCore", requirement: ">= 1.1.1", type: "runtime", source: "example-update.csproj"),
+        Bibliothecary::Dependency.new(name: "Microsoft.AspNetCore.StaticFiles", requirement: ">= 2.2.0", type: "runtime", source: "example-update.csproj"),
       ],
                                                                                                                      kind: "manifest",
                                                                                                                      success: true,
@@ -620,15 +620,64 @@ describe Bibliothecary::Parsers::Nuget do
     ])
   end
 
+  it "parses dependencies from .csproj with various ranges" do
+    csproj_content = <<~XML
+      <Project Sdk="Microsoft.NET.Sdk">
+        <PropertyGroup>
+          <TargetFramework>net6.0</TargetFramework>
+        </PropertyGroup>
+        <ItemGroup>
+          <PackageReference Include="SimpleVersion" Version="1.0" />
+          <PackageReference Include="InclusiveLowerBound" Version="[1.0,)" />
+          <PackageReference Include="ExclusiveLowerBound" Version="(1.0,)" />
+          <PackageReference Include="ExactVersion" Version="[1.0]" />
+          <PackageReference Include="InclusiveUpperBound" Version="(,1.0]" />
+          <PackageReference Include="ExclusiveUpperBound" Version="(,1.0)" />
+          <PackageReference Include="InclusiveRange" Version="[1.0,2.0]" />
+          <PackageReference Include="ExclusiveRange" Version="(1.0,2.0)" />
+          <PackageReference Include="InclusiveLowerExclusiveUpper" Version="[1.0,2.0)" />
+          <PackageReference Include="ExclusiveLowerInclusiveUpper" Version="(1.0,2.0]" />
+          <PackageReference Include="MinorWildcard" Version="1.*" />
+          <PackageReference Include="PatchWildcard" Version="1.2.*" />
+          <PackageReference Include="FullWildcard" Version="*" />
+          <PackageReference Include="NoVersion" />
+        </ItemGroup>
+      </Project>
+    XML
+
+    expect(described_class.analyse_contents("test.csproj", csproj_content)).to eq({
+                                                                                    platform: "nuget",
+                                                                                    path: "test.csproj",
+                                                                                    dependencies: [
+        Bibliothecary::Dependency.new(name: "SimpleVersion", requirement: ">= 1.0", type: "runtime", source: "test.csproj"),
+        Bibliothecary::Dependency.new(name: "InclusiveLowerBound", requirement: ">= 1.0", type: "runtime", source: "test.csproj"),
+        Bibliothecary::Dependency.new(name: "ExclusiveLowerBound", requirement: "> 1.0", type: "runtime", source: "test.csproj"),
+        Bibliothecary::Dependency.new(name: "ExactVersion", requirement: "1.0", type: "runtime", source: "test.csproj"),
+        Bibliothecary::Dependency.new(name: "InclusiveUpperBound", requirement: "<= 1.0", type: "runtime", source: "test.csproj"),
+        Bibliothecary::Dependency.new(name: "ExclusiveUpperBound", requirement: "< 1.0", type: "runtime", source: "test.csproj"),
+        Bibliothecary::Dependency.new(name: "InclusiveRange", requirement: ">= 1.0 <= 2.0", type: "runtime", source: "test.csproj"),
+        Bibliothecary::Dependency.new(name: "ExclusiveRange", requirement: "> 1.0 < 2.0", type: "runtime", source: "test.csproj"),
+        Bibliothecary::Dependency.new(name: "InclusiveLowerExclusiveUpper", requirement: ">= 1.0 < 2.0", type: "runtime", source: "test.csproj"),
+        Bibliothecary::Dependency.new(name: "ExclusiveLowerInclusiveUpper", requirement: "> 1.0 <= 2.0", type: "runtime", source: "test.csproj"),
+        Bibliothecary::Dependency.new(name: "MinorWildcard", requirement: "~> 1.0", type: "runtime", source: "test.csproj"),
+        Bibliothecary::Dependency.new(name: "PatchWildcard", requirement: ">= 1.0", type: "runtime", source: "test.csproj"),
+        Bibliothecary::Dependency.new(name: "FullWildcard", requirement: ">= 0", type: "runtime", source: "test.csproj"),
+        Bibliothecary::Dependency.new(name: "NoVersion", requirement: ">= 0", type: "runtime", source: "test.csproj"),
+      ],
+                                                                                    kind: "manifest",
+                                                                                    success: true,
+                                                                                  })
+  end
+
   it "parses dependencies from example.nuspec" do
     expect(described_class.analyse_contents("example.nuspec", load_fixture("example.nuspec"))).to eq({
                                                                                                        platform: "nuget",
                                                                                                        path: "example.nuspec",
                                                                                                        dependencies: [
-        Bibliothecary::Dependency.new(name: "FubuCore", requirement: "3.2.0.3001", type: "runtime", source: "example.nuspec"),
-        Bibliothecary::Dependency.new(name: "HtmlTags", requirement: "[3.2.0.3001]", type: "runtime", source: "example.nuspec"),
-        Bibliothecary::Dependency.new(name: "DotNetZip", requirement: "*", type: "runtime", source: "example.nuspec"),
-        Bibliothecary::Dependency.new(name: "DevelopmentOnlyPackage", requirement: "1.2.3", type: "development", source: "example.nuspec"),
+        Bibliothecary::Dependency.new(name: "FubuCore", requirement: ">= 3.2.0.3001", type: "runtime", source: "example.nuspec"),
+        Bibliothecary::Dependency.new(name: "HtmlTags", requirement: "3.2.0.3001", type: "runtime", source: "example.nuspec"),
+        Bibliothecary::Dependency.new(name: "DotNetZip", requirement: ">= 0", type: "runtime", source: "example.nuspec"),
+        Bibliothecary::Dependency.new(name: "DevelopmentOnlyPackage", requirement: ">= 1.2.3", type: "development", source: "example.nuspec"),
       ],
                                                                                                        kind: "manifest",
                                                                                                        success: true,


### PR DESCRIPTION
For the given `*.csproj` requirement, return `">= 1.2.3"` instead of `"1.2.3"`:

`<PackageReference Include="SomePackage" Version="1.2.3" />`

This change also applies all the other range equivalencies from the [Nuget docs](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort#version-ranges) so that we return [NPM-style](https://docs.npmjs.com/cli/v6/using-npm/semver) SemVer requirements instead of Nuget-style requirements.

This notably makes the Nuget requirements compatible with the [semantic_range](https://github.com/librariesio/semantic_range) gem too.

