### PR TITLE
13.1.0: Return Maven projects as Dependencies themselves, from "maven-dependency-tree.dot" lockfiles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [13.1.0] - 2025-07-15
+
+### Added
+
+- New Dependency#project field to denote that the dependency is the project itself.
+
+### Changed
+
+- Return the project dependency with dependencies from maven-dependency-tree.dot lockfiles.
+
 ## [13.0.1] - 2025-07-03
 
 ### Changed

--- a/lib/bibliothecary/dependency.rb
+++ b/lib/bibliothecary/dependency.rb
@@ -14,6 +14,7 @@ module Bibliothecary
   # @attr_reader [Boolean] deprecated Is this dependency deprecated? (default: nil)
   # @attr_reader [Boolean] local Is this dependency local? (default: nil)
   # @attr_reader [Boolean] optional Is this dependency optional? (default: nil)
+  # @attr_reader [Boolean] project Is this dependency the project itself? (default: nil)
   # @attr_reader [String] original_name The original name used to require the dependency, for cases
   #   where it did not match the resolved name. This can be used for features like aliasing.
   # @attr_reader [String] original_requirement The original requirement used to require the dependency,
@@ -31,6 +32,7 @@ module Bibliothecary
       deprecated
       local
       optional
+      project
       original_name
       source
     ].freeze
@@ -47,6 +49,7 @@ module Bibliothecary
       deprecated: nil,
       local: nil,
       optional: nil,
+      project: nil,
       original_name: nil,
       source: nil
     )
@@ -59,6 +62,7 @@ module Bibliothecary
       @deprecated = deprecated
       @local = local
       @optional = optional
+      @project = project
       @original_name = original_name
       @source = source
     end

--- a/spec/bibliothecary/dependency_spec.rb
+++ b/spec/bibliothecary/dependency_spec.rb
@@ -14,6 +14,7 @@ describe Bibliothecary::Dependency do
         deprecated: true,
         local: true,
         optional: true,
+        project: false,
         original_name: "foo-alias",
         original_requirement: "1.0.0.rc1",
         source: "package.json"
@@ -27,6 +28,7 @@ describe Bibliothecary::Dependency do
       expect(dep.deprecated).to eq(true)
       expect(dep.local).to eq(true)
       expect(dep.optional).to eq(true)
+      expect(dep.project).to eq(false)
       expect(dep.original_name).to eq("foo-alias")
       expect(dep.original_requirement).to eq("1.0.0.rc1")
       expect(dep.source).to eq("package.json")
@@ -61,6 +63,7 @@ describe Bibliothecary::Dependency do
         deprecated: true,
         local: true,
         optional: true,
+        project: false,
         original_name: "foo-alias",
         original_requirement: "1.0.0.rc1",
         source: "package.json",

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -785,7 +785,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
       project_dep = output.find { |dep| dep.name == "net.sourceforge.pmd:pmd-scala_2.12" }
       expect(project_dep).to_not be_nil
       expect(project_dep.project).to be(true)
-      expect(output.partition { |dep| dep.project }.map(&:size)).to eq([1, 75])
+      expect(output.partition(&:project).map(&:size)).to eq([1, 75])
 
       direct_example = output.find { |d| d.name == "com.github.oowekyala.treeutils:tree-printers" && d.requirement == "2.1.0" }
       expect(direct_example.direct).to be(true)

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -779,10 +779,13 @@ RSpec.describe Bibliothecary::Parsers::Maven do
       contents = load_fixture("maven-dependency-tree.dot")
       output = described_class.parse_maven_tree_dot(contents)
 
-      expect(output.size).to eq(75)
+      expect(output.size).to eq(76)
 
-      # Exclude parent project
-      expect(output.none? { |dep| dep.name == "net.sourceforge.pmd:pmd-scala_2.12" }).to be(true)
+      # Include project dep with a "project: true" flag
+      project_dep = output.find { |dep| dep.name == "net.sourceforge.pmd:pmd-scala_2.12" }
+      expect(project_dep).to_not be_nil
+      expect(project_dep.project).to be(true)
+      expect(output.partition { |dep| dep.project }.map(&:size)).to eq([1, 75])
 
       direct_example = output.find { |d| d.name == "com.github.oowekyala.treeutils:tree-printers" && d.requirement == "2.1.0" }
       expect(direct_example.direct).to be(true)


### PR DESCRIPTION
This enables bibliothecary to denote what the project name/version for a list of dependencies is, by:

* adding `Dependendency#project` boolean, which is true when the dependency is the project itself (default: nil)
* Maven: start returning a Dependency for the project itself from `maven-dependency-tree.dot` manifests, which will be marked `project: true`

Upsides: 
* it's much simpler than the alternative of returning a new "project_name" field for each analysis result, which would require changing every manifest-parsing method to support. 
* this might also be useful for Gradle projects, etc

Downsides:
* it's debatable if the project itself can be considered a dependency.

Thoughts?