### PR TITLE
13.0.2: handle scoped dependencies in PNPM v5, v6, and v9 lockfiles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [13.0.2] - 2025-07-21
+
+### Changed
+
+- Handle scoped dependencies in PNPM lockfiles.
+
 ## [13.0.1] - 2025-07-03
 
 ### Changed

--- a/lib/bibliothecary/parsers/npm.rb
+++ b/lib/bibliothecary/parsers/npm.rb
@@ -263,8 +263,8 @@ module Bibliothecary
 
         parsed_contents["packages"]
           .map do |name_version, details|
-            # e.g. "/debug/2.6.9:"
-            name, version = name_version.sub(/^\//, "").split("/", 2)
+            # e.g. "/debug/2.6.9" or "/@babel/types/7.28.1"
+            name, _slash, version = name_version.sub(/^\//, "").rpartition("/")
 
             # e.g. "/debug/2.2.0_supports-color@1.2.0:"
             version = version.split("_", 2)[0]

--- a/lib/bibliothecary/parsers/npm.rb
+++ b/lib/bibliothecary/parsers/npm.rb
@@ -297,7 +297,7 @@ module Bibliothecary
         parsed_contents["packages"]
           .map do |name_version, details|
             # e.g. "/debug@2.6.9:"
-            name, version = name_version.sub(/^\//, "").split("@", 2)
+            name, version = name_version.sub(/^\//, "").split(/(?<!^)@/, 2)
 
             # e.g. "debug@2.2.0(supports-color@1.2.0)"
             version = version.split("(", 2).first

--- a/lib/bibliothecary/parsers/npm.rb
+++ b/lib/bibliothecary/parsers/npm.rb
@@ -335,8 +335,8 @@ module Bibliothecary
         # as of https://github.com/pnpm/pnpm/pull/7700.
         parsed_contents["snapshots"]
           .map do |name_version, _details|
-            # e.g. "debug@2.6.9:"
-            name, version = name_version.split("@", 2)
+            # e.g. "debug@2.6.9" or "@babel/types@7.28.1"
+            name, version = name_version.split(/(?<!^)@/, 2)
 
             # e.g. "debug@2.2.0(supports-color@1.2.0)"
             version = version.split("(", 2).first

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bibliothecary
-  VERSION = "13.0.1"
+  VERSION = "13.0.2"
 end

--- a/spec/fixtures/pnpm-lockfile-version-5/package.json
+++ b/spec/fixtures/pnpm-lockfile-version-5/package.json
@@ -11,7 +11,8 @@
   "license": "MIT",
   "dependencies": {
     "babel": "^4.6.6",
-    "alias-package": "npm:zod"
+    "alias-package": "npm:zod",
+    "@babel/types": "^7.28.0"
   },
   "devDependencies": {
     "mocha": "^2.2.1"

--- a/spec/fixtures/pnpm-lockfile-version-5/pnpm-lock.yaml
+++ b/spec/fixtures/pnpm-lockfile-version-5/pnpm-lock.yaml
@@ -1,19 +1,38 @@
-# Generated with PNPM 7.33.5
 lockfileVersion: 5.4
 
 specifiers:
+  '@babel/types': ^7.28.0
   alias-package: npm:zod
   babel: ^4.6.6
   mocha: ^2.2.1
 
 dependencies:
-  alias-package: /zod/3.24.2
+  '@babel/types': 7.28.1
+  alias-package: /zod/4.0.5
   babel: 4.7.16
 
 devDependencies:
   mocha: 2.5.3
 
 packages:
+
+  /@babel/helper-string-parser/7.27.1:
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+    dev: false
+
+  /@babel/helper-validator-identifier/7.27.1:
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+    dev: false
+
+  /@babel/types/7.28.1:
+    resolution: {integrity: sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+    dev: false
 
   /acorn-babel/0.11.1-38:
     resolution: {integrity: sha512-lsXiveYSiYLMo9flCOZRtfW/txWHGLvrqvpQ/aVIHmwxSFXagy94crhyAmSJ1qttKmSuPU9SmmIFJqdbr3nS0Q==}
@@ -693,6 +712,6 @@ packages:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
     dev: false
 
-  /zod/3.24.2:
-    resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
+  /zod/4.0.5:
+    resolution: {integrity: sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==}
     dev: false

--- a/spec/fixtures/pnpm-lockfile-version-6/package.json
+++ b/spec/fixtures/pnpm-lockfile-version-6/package.json
@@ -11,7 +11,8 @@
   "license": "MIT",
   "dependencies": {
     "babel": "^4.6.6",
-    "alias-package": "npm:zod"
+    "alias-package": "npm:zod",
+    "@babel/types": "^7.28.0"
   },
   "devDependencies": {
     "mocha": "^2.2.1"

--- a/spec/fixtures/pnpm-lockfile-version-6/pnpm-lock.yaml
+++ b/spec/fixtures/pnpm-lockfile-version-6/pnpm-lock.yaml
@@ -6,9 +6,12 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@babel/types':
+    specifier: ^7.28.0
+    version: 7.28.1
   alias-package:
     specifier: npm:zod
-    version: /zod@3.24.2
+    version: /zod@4.0.5
   babel:
     specifier: ^4.6.6
     version: 4.7.16
@@ -19,6 +22,24 @@ devDependencies:
     version: 2.5.3
 
 packages:
+
+  /@babel/helper-string-parser@7.27.1:
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+    dev: false
+
+  /@babel/helper-validator-identifier@7.27.1:
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+    dev: false
+
+  /@babel/types@7.28.1:
+    resolution: {integrity: sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+    dev: false
 
   /acorn-babel@0.11.1-38:
     resolution: {integrity: sha512-lsXiveYSiYLMo9flCOZRtfW/txWHGLvrqvpQ/aVIHmwxSFXagy94crhyAmSJ1qttKmSuPU9SmmIFJqdbr3nS0Q==}
@@ -107,8 +128,8 @@ packages:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: false
 
-  /brace-expansion@1.1.11:
-    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+  /brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -279,7 +300,7 @@ packages:
     os: [darwin]
     requiresBuild: true
     dependencies:
-      nan: 2.22.2
+      nan: 2.23.0
     dev: false
     optional: true
 
@@ -428,7 +449,7 @@ packages:
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
-      brace-expansion: 1.1.11
+      brace-expansion: 1.1.12
     dev: false
 
   /minimist@0.0.8:
@@ -484,8 +505,8 @@ packages:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
     dev: false
 
-  /nan@2.22.2:
-    resolution: {integrity: sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==}
+  /nan@2.23.0:
+    resolution: {integrity: sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==}
     requiresBuild: true
     dev: false
     optional: true
@@ -699,6 +720,6 @@ packages:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
     dev: false
 
-  /zod@3.24.2:
-    resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
+  /zod@4.0.5:
+    resolution: {integrity: sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==}
     dev: false

--- a/spec/fixtures/pnpm-lockfile-version-9/package.json
+++ b/spec/fixtures/pnpm-lockfile-version-9/package.json
@@ -11,7 +11,8 @@
   "license": "MIT",
   "dependencies": {
     "babel": "^4.6.6",
-    "alias-package": "npm:zod"
+    "alias-package": "npm:zod",
+    "@babel/types": "^7.28.0"
   },
   "devDependencies": {
     "mocha": "^2.2.1"

--- a/spec/fixtures/pnpm-lockfile-version-9/pnpm-lock.yaml
+++ b/spec/fixtures/pnpm-lockfile-version-9/pnpm-lock.yaml
@@ -9,6 +9,9 @@ importers:
 
   .:
     dependencies:
+      '@babel/types':
+        specifier: ^7.28.0
+        version: 7.28.1
       alias-package:
         specifier: npm:zod
         version: zod@3.24.2
@@ -21,6 +24,18 @@ importers:
         version: 2.5.3
 
 packages:
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.28.1':
+    resolution: {integrity: sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==}
+    engines: {node: '>=6.9.0'}
 
   acorn-babel@0.11.1-38:
     resolution: {integrity: sha512-lsXiveYSiYLMo9flCOZRtfW/txWHGLvrqvpQ/aVIHmwxSFXagy94crhyAmSJ1qttKmSuPU9SmmIFJqdbr3nS0Q==}
@@ -435,6 +450,15 @@ packages:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
 
 snapshots:
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/types@7.28.1':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
 
   acorn-babel@0.11.1-38: {}
 

--- a/spec/parsers/npm_spec.rb
+++ b/spec/parsers/npm_spec.rb
@@ -279,6 +279,9 @@ describe Bibliothecary::Parsers::NPM do
 
   it "parses dependencies from pnpm-lock.yaml with lockfile version 6" do
     expected_deps = [
+      Bibliothecary::Dependency.new(name: "@babel/helper-string-parser", requirement: "7.27.1", type: "runtime", source: "pnpm-lock.yaml"),
+      Bibliothecary::Dependency.new(name: "@babel/helper-validator-identifier", requirement: "7.27.1", type: "runtime", source: "pnpm-lock.yaml"),
+      Bibliothecary::Dependency.new(name: "@babel/types", requirement: "7.28.1", type: "runtime", source: "pnpm-lock.yaml"),
       Bibliothecary::Dependency.new(name: "acorn-babel", requirement: "0.11.1-38", type: "runtime", source: "pnpm-lock.yaml"),
       Bibliothecary::Dependency.new(name: "acorn", requirement: "5.7.4", type: "runtime", source: "pnpm-lock.yaml"),
       Bibliothecary::Dependency.new(name: "amdefine", requirement: "1.0.1", type: "runtime", source: "pnpm-lock.yaml"),
@@ -290,7 +293,7 @@ describe Bibliothecary::Parsers::NPM do
       Bibliothecary::Dependency.new(name: "async-each", requirement: "0.1.6", type: "runtime", source: "pnpm-lock.yaml"),
       Bibliothecary::Dependency.new(name: "babel", requirement: "4.7.16", type: "runtime", source: "pnpm-lock.yaml"),
       Bibliothecary::Dependency.new(name: "balanced-match", requirement: "1.0.2", type: "runtime", source: "pnpm-lock.yaml"),
-      Bibliothecary::Dependency.new(name: "brace-expansion", requirement: "1.1.11", type: "runtime", source: "pnpm-lock.yaml"),
+      Bibliothecary::Dependency.new(name: "brace-expansion", requirement: "1.1.12", type: "runtime", source: "pnpm-lock.yaml"),
       Bibliothecary::Dependency.new(name: "chalk", requirement: "1.1.3", type: "runtime", source: "pnpm-lock.yaml"),
       Bibliothecary::Dependency.new(name: "chokidar", requirement: "0.12.6", type: "runtime", source: "pnpm-lock.yaml"),
       Bibliothecary::Dependency.new(name: "commander", requirement: "0.6.1", type: "development", source: "pnpm-lock.yaml"),
@@ -349,7 +352,7 @@ describe Bibliothecary::Parsers::NPM do
       Bibliothecary::Dependency.new(name: "mocha", requirement: "2.5.3", type: "development", source: "pnpm-lock.yaml"),
       Bibliothecary::Dependency.new(name: "ms", requirement: "0.7.1", type: "development", source: "pnpm-lock.yaml"),
       Bibliothecary::Dependency.new(name: "ms", requirement: "2.0.0", type: "runtime", source: "pnpm-lock.yaml"),
-      Bibliothecary::Dependency.new(name: "nan", requirement: "2.22.2", type: "runtime", source: "pnpm-lock.yaml"),
+      Bibliothecary::Dependency.new(name: "nan", requirement: "2.23.0", type: "runtime", source: "pnpm-lock.yaml"),
       Bibliothecary::Dependency.new(name: "object-assign", requirement: "4.1.1", type: "runtime", source: "pnpm-lock.yaml"),
       Bibliothecary::Dependency.new(name: "once", requirement: "1.4.0", type: "runtime", source: "pnpm-lock.yaml"),
       Bibliothecary::Dependency.new(name: "output-file-sync", requirement: "1.1.2", type: "runtime", source: "pnpm-lock.yaml"),
@@ -383,7 +386,7 @@ describe Bibliothecary::Parsers::NPM do
       Bibliothecary::Dependency.new(name: "to-iso-string", requirement: "0.0.2", type: "development", source: "pnpm-lock.yaml"),
       Bibliothecary::Dependency.new(name: "trim-right", requirement: "1.0.1", type: "runtime", source: "pnpm-lock.yaml"),
       Bibliothecary::Dependency.new(name: "wrappy", requirement: "1.0.2", type: "runtime", source: "pnpm-lock.yaml"),
-      Bibliothecary::Dependency.new(name: "zod", requirement: "3.24.2", original_name: "alias-package", original_requirement: "3.24.2", type: "runtime", source: "pnpm-lock.yaml"),
+      Bibliothecary::Dependency.new(name: "zod", requirement: "4.0.5", original_name: "alias-package", original_requirement: "4.0.5", type: "runtime", source: "pnpm-lock.yaml"),
 ]
     result = described_class.analyse_contents("pnpm-lock.yaml", load_fixture("pnpm-lockfile-version-6/pnpm-lock.yaml"))
 

--- a/spec/parsers/npm_spec.rb
+++ b/spec/parsers/npm_spec.rb
@@ -398,6 +398,9 @@ describe Bibliothecary::Parsers::NPM do
 
   it "parses dependencies from pnpm-lock.yaml with lockfile version 9" do
     expected_deps = [
+      Bibliothecary::Dependency.new(name: "@babel/helper-string-parser", requirement: "7.27.1", type: "runtime", source: "pnpm-lock.yaml"),
+      Bibliothecary::Dependency.new(name: "@babel/helper-validator-identifier", requirement: "7.27.1", type: "runtime", source: "pnpm-lock.yaml"),
+      Bibliothecary::Dependency.new(name: "@babel/types", requirement: "7.28.1", type: "runtime", source: "pnpm-lock.yaml"),
       Bibliothecary::Dependency.new(name: "acorn-babel", requirement: "0.11.1-38", type: "runtime", source: "pnpm-lock.yaml"),
       Bibliothecary::Dependency.new(name: "acorn", requirement: "5.7.4", type: "runtime", source: "pnpm-lock.yaml"),
       Bibliothecary::Dependency.new(name: "amdefine", requirement: "1.0.1", type: "runtime", source: "pnpm-lock.yaml"),

--- a/spec/parsers/npm_spec.rb
+++ b/spec/parsers/npm_spec.rb
@@ -160,6 +160,9 @@ describe Bibliothecary::Parsers::NPM do
 
   it "parses dependencies from pnpm-lock.yaml with lockfile version 5" do
     expected_deps = [
+      Bibliothecary::Dependency.new(name: "@babel/helper-string-parser", requirement: "7.27.1", type: "runtime", source: "pnpm-lock.yaml"),
+      Bibliothecary::Dependency.new(name: "@babel/helper-validator-identifier", requirement: "7.27.1", type: "runtime", source: "pnpm-lock.yaml"),
+      Bibliothecary::Dependency.new(name: "@babel/types", requirement: "7.28.1", type: "runtime", source: "pnpm-lock.yaml"),
       Bibliothecary::Dependency.new(name: "acorn-babel", requirement: "0.11.1-38", type: "runtime", source: "pnpm-lock.yaml"),
       Bibliothecary::Dependency.new(name: "acorn", requirement: "5.7.4", type: "runtime", source: "pnpm-lock.yaml"),
       Bibliothecary::Dependency.new(name: "amdefine", requirement: "1.0.1", type: "runtime", source: "pnpm-lock.yaml"),
@@ -264,7 +267,7 @@ describe Bibliothecary::Parsers::NPM do
       Bibliothecary::Dependency.new(name: "to-iso-string", requirement: "0.0.2", type: "development", source: "pnpm-lock.yaml"),
       Bibliothecary::Dependency.new(name: "trim-right", requirement: "1.0.1", type: "runtime", source: "pnpm-lock.yaml"),
       Bibliothecary::Dependency.new(name: "wrappy", requirement: "1.0.2", type: "runtime", source: "pnpm-lock.yaml"),
-      Bibliothecary::Dependency.new(name: "zod", requirement: "3.24.2", original_name: "alias-package", original_requirement: "3.24.2", type: "runtime", source: "pnpm-lock.yaml"),
+      Bibliothecary::Dependency.new(name: "zod", requirement: "4.0.5", original_name: "alias-package", original_requirement: "4.0.5", type: "runtime", source: "pnpm-lock.yaml"),
 ]
     result = described_class.analyse_contents("pnpm-lock.yaml", load_fixture("pnpm-lockfile-version-5/pnpm-lock.yaml"))
 


### PR DESCRIPTION
Previously we weren't parsing deps like `@babel/types` correctly because of the ampersand, so this fix includes those deps correctly.