### PR TITLE
Remove some leftovers from old "generic" parser code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removed unused generic parser code.
+
 ## [13.0.2] - 2025-07-21
 
 ### Changed

--- a/lib/bibliothecary/analyser.rb
+++ b/lib/bibliothecary/analyser.rb
@@ -50,10 +50,6 @@ module Bibliothecary
     end
 
     module ClassMethods
-      def generic?
-        platform_name == "generic"
-      end
-
       def platform_name
         name.to_s.split("::").last.downcase
       end

--- a/lib/bibliothecary/analyser/analysis.rb
+++ b/lib/bibliothecary/analyser/analysis.rb
@@ -50,24 +50,7 @@ module Bibliothecary
 
       def dependencies_to_analysis(info, kind, dependencies)
         dependencies ||= [] # work around any legacy parsers that return nil
-        if generic?
-          grouped = dependencies.group_by { |dep| dep[:platform] }
-          all_analyses = grouped.keys.map do |platform|
-            deplatformed_dependencies = grouped[platform].map do |d|
-              d.delete(:platform)
-              d
-            end
-            Bibliothecary::Analyser.create_analysis(platform, info.relative_path, kind, deplatformed_dependencies)
-          end
-          # this is to avoid a larger refactor for the time being. The larger refactor
-          # needs to make analyse_contents return multiple analysis, or add another
-          # method that can return multiple and deprecate analyse_contents, perhaps.
-          raise "File contains zero or multiple platforms, currently must have exactly one" if all_analyses.length != 1
-
-          all_analyses.first
-        else
-          Bibliothecary::Analyser.create_analysis(platform_name, info.relative_path, kind, dependencies)
-        end
+        Bibliothecary::Analyser.create_analysis(platform_name, info.relative_path, kind, dependencies)
       end
 
       # Call the matching parse class method for this file with


### PR DESCRIPTION
The "Generic" type was added in https://github.com/librariesio/bibliothecary/pull/519 and then removed in https://github.com/librariesio/bibliothecary/pull/533.
