### PR TITLE
[15.2.0] Require opt-in for gradle-dependencies-q.txt subprojects, and handle one more "project_name" case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [15.2.0]
+
+### Changed
+
+- The format of Gradle sub-project GAVs that were found in a dependency tree has changed from "internal:my-subproject:1.0.0" to ":my-subproject:*".
+- Gradle dependencies in gradle-dependencies-q.txt with "(n)" suffix will be ignored in favor of their resolved dependencies, so the full dependency list could now be smaller but still correct.
+
+### Added
+
+- Added support for another project name pattern in gradle-dependencies-q.txt lockfiles.
+
 ## [15.1.3]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Exclude sub-projects in gradle-dependencies-q.txt unless keep_subprojects_in_maven_tree is true.
 - The format of Gradle sub-project GAVs that were found in a dependency tree has changed from "internal:my-subproject:1.0.0" to ":my-subproject:*".
 - Gradle dependencies in gradle-dependencies-q.txt with "(n)" suffix will be ignored in favor of their resolved dependencies, so the full dependency list could now be smaller but still correct.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Start collecting "project_name" from gradle-dependencies-q.txt lockfiles.
 - Start collecting "project_name" from package.json manifests.
 
+### Changed
+
+- Bibliothecary::Parsers::Maven's GRADLE_PROJECT_REGEXP constant was renamed to GRADLE_DEPENDENCY_PROJECT_REGEXP.
+
 ### Removed
 
 - Remove "go.sum" as a lockfile for Golang because it is not a lockfile.

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -21,7 +21,8 @@ module Bibliothecary
       # e.g. "|    \\--- com.google.guava:guava:23.5-jre (*)"
       GRADLE_DEP_REGEXP = /(\+---|\\---){1}/
 
-      GRADLE_PROJECT_REGEXP = /\s*Project '?:?([^\s']+)'?/
+      # The name of the project containing the given dependencies
+      GRADLE_PROJECT_REGEXP = /\s*(Root p|P)roject '?:?([^\s']+)'?/
 
       # Dependencies that are on-disk projects, eg:
       # e.g. "\--- project :api:my-internal-project"
@@ -197,7 +198,7 @@ module Bibliothecary
 
         dependencies = file_contents.split("\n").map do |line|
           if project_name.nil? && (project_name_match = GRADLE_PROJECT_REGEXP.match(line))
-            project_name = project_name_match.captures[0]
+            project_name = project_name_match.captures[1]
             next
           end
 

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -21,13 +21,15 @@ module Bibliothecary
       # e.g. "|    \\--- com.google.guava:guava:23.5-jre (*)"
       GRADLE_DEP_REGEXP = /(\+---|\\---){1}/
 
+      GRADLE_ARROW_REGEXP = / -> /
+
       # The name of the project containing the given dependencies
       GRADLE_PROJECT_REGEXP = /\s*(Root p|P)roject '?:?([^\s']+)'?/
 
       # Dependencies that are on-disk projects, eg:
       # e.g. "\--- project :api:my-internal-project"
       # e.g. "+--- my-group:my-alias:1.2.3 -> project :client (*)"
-      GRADLE_DEPENDENCY_PROJECT_REGEXP = /project :(\S+)?/
+      GRADLE_DEPENDENCY_SUB_PROJECT_REGEXP = /project :?(\S+)?/
 
       # line ending legend: (c) means a dependency constraint, (n) means not resolved, or (*) means resolved previously, e.g. org.springframework.boot:spring-boot-starter-web:2.1.0.M3 (*)
       # e.g. the "(n)" in "+--- my-group:my-name:1.2.3 (n)"
@@ -46,6 +48,8 @@ module Bibliothecary
       GRADLE_GAV_REGEXP = /([\w.-]+):([\w.-]+)(?::(#{GRADLE_VERSION_REGEXP}|#{GRADLE_VAR_INTERPOLATION_REGEXP}|#{GRADLE_CODE_INTERPOLATION_REGEXP}))?/ # e.g. "group:artifactId:1.2.3"
       GRADLE_GROOVY_SIMPLE_REGEXP = /(#{GRADLE_DEPENDENCY_METHODS.join('|')})\s*\(?\s*['"]#{GRADLE_GAV_REGEXP}['"]/m
       GRADLE_KOTLIN_SIMPLE_REGEXP = /(#{GRADLE_DEPENDENCY_METHODS.join('|')})\s*\(\s*"#{GRADLE_GAV_REGEXP}"/m
+
+      GRADLE_RESOLVED_DEPENDENCY_REGEXP = /^([\w.-]+(?::[\w.-]+)?)(?::([\w.-]+))?$/ # either 1 capture (version) or 2 captures (name, version)
 
       MAVEN_PROPERTY_REGEXP = /\$\{(.+?)\}/
       MAX_DEPTH = 5
@@ -196,7 +200,9 @@ module Bibliothecary
         current_type = nil
         project_name = nil
 
-        dependencies = file_contents.split("\n").map do |line|
+        dependencies = file_contents.lines.filter_map do |line|
+          next if line.strip.end_with?("(n)") # unresolved or already-resolved dependencies
+
           if project_name.nil? && (project_name_match = GRADLE_PROJECT_REGEXP.match(line))
             project_name = project_name_match.captures[1]
             next
@@ -208,66 +214,66 @@ module Bibliothecary
           gradle_dep_match = GRADLE_DEP_REGEXP.match(line)
           next unless gradle_dep_match
 
-          split = gradle_dep_match.captures[0]
-
-          # gradle can import on-disk projects and deps will be listed under them, e.g. `+--- project :test:integration`,
-          # so we treat these projects as "internal" deps with requirement of "1.0.0"
-          if (project_match = line.match(GRADLE_DEPENDENCY_PROJECT_REGEXP))
-            # an empty project name is self-referential (i.e. a cycle), and we don't need to track the manifest's project itself, e.g. "+--- project :"
+          # support gradle multi-project build dependencies
+          if (project_match = line.match(GRADLE_DEPENDENCY_SUB_PROJECT_REGEXP))
+            # an empty project name is self-referential (i.e. a cycle), and we don't need to track the manifest's
+            # project itself, e.g. "+--- project :"
             next if project_match[1].nil?
 
-            # project names can have colons (e.g. for gradle projects in subfolders), which breaks maven artifact naming assumptions, so just replace them with hyphens.
-            project_name = project_match[1].gsub(":", "-")
-            line = line.sub(GRADLE_DEPENDENCY_PROJECT_REGEXP, "internal:#{project_name}:1.0.0")
+            sub_project_name = project_match[1]
+            # gradle sub-project versions cannot be specified when including them (gradle just uses whichever version is in the
+            # codebase), and their versions are 'unspecified' if not set, so just use a wildcard placeholder since it doesn't matter.
+            line = line.sub(GRADLE_DEPENDENCY_SUB_PROJECT_REGEXP, ":#{sub_project_name}:*")
           end
 
-          dep = line
-            .split(split)[1]
+          cleaned_line = line
+            .split(gradle_dep_match.captures[0])[1]
             .sub(GRADLE_LINE_ENDING_REGEXP, "")
             .sub(/ FAILED$/, "") # dependency could not be resolved (but still may have a version)
-            .sub(" -> ", ":") # handle version arrow syntax
             .strip
-            .split(":")
 
-          # A testImplementation line can look like this so just skip those
-          # \--- org.springframework.security:spring-security-test (n)
-          next unless dep.length >= 3
+          # " -> " is either for an aliased dependency, or a version that was resolved from a different requirement or no requirement.
+          if cleaned_line =~ GRADLE_ARROW_REGEXP
+            original_depstring, resolved_depstring = *cleaned_line.split(GRADLE_ARROW_REGEXP, 2)
 
-          if dep.count == 6
-            # get name from renamed package resolution "org:name:version -> renamed_org:name:version"
-            Dependency.new(
-              original_name: dep[0, 2].join(":"),
-              original_requirement: dep[2],
-              name: dep[-3..-2].join(":"),
-              requirement: dep[-1],
-              type: current_type,
-              source: options.fetch(:filename, nil),
-              platform: platform_name
-            )
-          elsif dep.count == 5
-            # get name from renamed package resolution "org:name -> renamed_org:name:version"
-            Dependency.new(
-              original_name: dep[0, 2].join(":"),
-              original_requirement: "*",
-              name: dep[-3..-2].join(":"),
-              requirement: dep[-1],
-              type: current_type,
-              source: options.fetch(:filename, nil),
-              platform: platform_name
-            )
+            parts = original_depstring.split(":")
+            original_name = parts[0..1].join(":") # original at minimum will have a 2-part name
+            original_requirement = parts[2] || "*"
+
+            parts = resolved_depstring.split(":")
+            resolved_requirement = parts.pop # resolved at minimum will have a 1-part version
+            resolved_name = parts.join(":")
+
+            # this case is not an actual alias, just a different version was resolved, so won't keep track of original
+            if resolved_name.empty? && !original_name.empty?
+              resolved_name = original_name
+              original_name = nil
+              original_requirement = nil
+            end
           else
-            # get name from version conflict resolution ("org:name:version -> version") and no-resolution ("org:name:version")
-            Dependency.new(
-              name: dep[0..1].join(":"),
-              requirement: dep[-1],
-              type: current_type,
-              source: options.fetch(:filename, nil),
-              platform: platform_name
-            )
+            original_name = nil
+            original_requirement = nil
+
+            # handle simple resolved dep
+            parts = cleaned_line.split(":")
+            next if parts.size < 3 # we didn't get a full name and version, so skip it
+
+            resolved_requirement = parts.pop
+            resolved_name = parts.join(":")
           end
+
+          Dependency.new(
+            original_name: original_name,
+            original_requirement: original_requirement,
+            name: resolved_name,
+            requirement: resolved_requirement,
+            type: current_type,
+            source: options.fetch(:filename, nil),
+            platform: platform_name
+          )
         end
-          .compact
           .uniq { |item| [item.name, item.requirement, item.type, item.original_name, item.original_requirement] }
+
         ParserResult.new(
           project_name: project_name,
           dependencies: dependencies

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bibliothecary
-  VERSION = "15.1.3"
+  VERSION = "15.2.0"
 end

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -888,6 +888,19 @@ RSpec.describe Bibliothecary::Parsers::Maven do
         ],
                             })
     end
+
+    it "parses root project name from gradle-dependencies-q.txt, generated from a multi-project Gradle build" do
+      lockfile = <<~FILE
+        ------------------------------------------------------------
+        Root project 'build-logic'
+        ------------------------------------------------------------
+      FILE
+
+      results = described_class.analyse_contents("gradle-dependencies-q.txt", lockfile)
+      puts results
+      expect(results[:success]).to be true
+      expect(results[:project_name]).to eq("build-logic")
+    end
   end
 
   describe "parse_pom_manifests" do

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -598,7 +598,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
     it "parses dependencies from gradle-dependencies-q.txt" do
       deps = described_class.analyse_contents("gradle-dependencies-q.txt", load_fixture("gradle-dependencies-q.txt"))
       expect(deps[:kind]).to eq "lockfile"
-      guavas = deps[:dependencies].select { |item| item.name == "com.google.guava:guava" && item.type == "api" }
+      guavas = deps[:dependencies].select { |item| item.name == "com.google.guava:guava" && item.type == "compileClasspath" }
       expect(guavas.length).to eq 1
       expect(guavas[0].requirement).to eq "25.1-jre"
     end
@@ -652,15 +652,15 @@ RSpec.describe Bibliothecary::Parsers::Maven do
         .to eq(Bibliothecary::ParserResult.new(dependencies: []))
     end
 
-    it "includes local projects as deps with 'internal' group and '1.0.0' requirement" do
-      expect(described_class.parse_gradle_resolved("+--- project :api:my-internal-project"))
+    it "includes local projects as deps with '*' requirement" do
+      expect(described_class.parse_gradle_resolved("+--- project :acme:my-internal-project"))
         .to eq(Bibliothecary::ParserResult.new(
-                 project_name: "api-my-internal-project",
+                 project_name: nil,
                  dependencies: [
                    Bibliothecary::Dependency.new(
                      platform: "maven",
-                     name: "internal:api-my-internal-project",
-                     requirement: "1.0.0",
+                     name: ":acme:my-internal-project",
+                     requirement: "*",
                      type: nil
                    ),
                ]
@@ -670,12 +670,12 @@ RSpec.describe Bibliothecary::Parsers::Maven do
     it "includes aliases to local projects" do
       expect(described_class.parse_gradle_resolved("|    +--- my-group:common-job-update-gateway-compress:5.0.2 -> project :client (*)"))
         .to eq(Bibliothecary::ParserResult.new(
-                 project_name: "client",
+                 project_name: nil,
                  dependencies: [
                    Bibliothecary::Dependency.new(
                      platform: "maven",
-                     name: "internal:client",
-                     requirement: "1.0.0",
+                     name: ":client",
+                     requirement: "*",
                      original_name: "my-group:common-job-update-gateway-compress",
                      original_requirement: "5.0.2",
                      type: nil
@@ -843,14 +843,13 @@ RSpec.describe Bibliothecary::Parsers::Maven do
       expect(results).to eq({
                               parser: "maven",
                               path: "gradle-dependencies-q.txt",
-                              project_name: "list",
+                              project_name: "utilities",
                               kind: "lockfile",
                               success: true,
                               dependencies: [
-          Bibliothecary::Dependency.new(name: "internal:list", requirement: "1.0.0", type: "compileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
+          Bibliothecary::Dependency.new(name: ":list", requirement: "*", type: "compileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "org.fusesource.jansi:jansi", requirement: "2.4.1", type: "compileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
-          Bibliothecary::Dependency.new(name: "org.fusesource.jansi:jansi", requirement: "2.4.1", type: "implementation", platform: "maven", source: "gradle-dependencies-q.txt"),
-          Bibliothecary::Dependency.new(name: "internal:list", requirement: "1.0.0", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
+          Bibliothecary::Dependency.new(name: ":list", requirement: "*", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "com.google.guava:guava", requirement: "33.0.0-jre", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "com.google.guava:failureaccess", requirement: "1.0.2", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "com.google.guava:listenablefuture", requirement: "9999.0-empty-to-avoid-conflict-with-guava", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
@@ -858,7 +857,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
           Bibliothecary::Dependency.new(name: "org.checkerframework:checker-qual", requirement: "3.41.0", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "com.google.errorprone:error_prone_annotations", requirement: "2.23.0", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "org.fusesource.jansi:jansi", requirement: "2.4.1", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
-          Bibliothecary::Dependency.new(name: "internal:list", requirement: "1.0.0", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
+          Bibliothecary::Dependency.new(name: ":list", requirement: "*", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "org.fusesource.jansi:jansi", requirement: "2.4.1", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "org.junit.jupiter:junit-jupiter", requirement: "5.12.1", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "org.junit:junit-bom", requirement: "5.12.1", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
@@ -867,8 +866,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
           Bibliothecary::Dependency.new(name: "org.junit.platform:junit-platform-commons", requirement: "1.12.1", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "org.opentest4j:opentest4j", requirement: "1.3.0", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "org.apiguardian:apiguardian-api", requirement: "1.1.2", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
-          Bibliothecary::Dependency.new(name: "org.junit.jupiter:junit-jupiter", requirement: "5.12.1", type: "testImplementation", platform: "maven", source: "gradle-dependencies-q.txt"),
-          Bibliothecary::Dependency.new(name: "internal:list", requirement: "1.0.0", type: "testRuntimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
+          Bibliothecary::Dependency.new(name: ":list", requirement: "*", type: "testRuntimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "com.google.guava:guava", requirement: "33.0.0-jre", type: "testRuntimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "com.google.guava:failureaccess", requirement: "1.0.2", type: "testRuntimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "com.google.guava:listenablefuture", requirement: "9999.0-empty-to-avoid-conflict-with-guava", type: "testRuntimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),


### PR DESCRIPTION
Changes:

* omit subprojects from `gradle-dependencies-q.txt` deps unless `keep_subprojects_in_maven_tree` is set to true (this is how `maven-dependency-tree.txt` works too)
* pick up a new local project name pattern:

Before this we'd pick up this case:

```
Project ':utilities'
------------------------------------------------------------
```

After this change we'll also pick up:

```
------------------------------------------------------------
Root project 'build-logic'
------------------------------------------------------------
```
