### PR TITLE
15.3.0: Extract a "parse_resolved_gradle_dep_line" method in gradle-dependencies-q.txt parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Return the leading ":" with Gradle project names from gradle-dependencies-q.txt.
+- Return the leading ":" with Gradle project names from gradle-dependencies-q.txt, and use "0.0.0" for a version instead of "*" since this is a lockfie.
+
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Adds a new Bibliothecary::Parsers::Maven.parse_resolved_gradle_dep_line() method for parsing a single line in gradle-dependencies-q.txt.
+- Adds a new Bibliothecary::Parsers::Maven.parse_resolved_gradle_dep_line() method for parsing a single line in gradle-dependencies-q.txt, and optimize it a bit.
 
 ## [15.2.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Removed
+
+## [15.2.1]
+
+### Added
+
 - Adds a new Bibliothecary::Parsers::Maven.parse_resolved_gradle_dep_line() method for parsing a single line in gradle-dependencies-q.txt, and optimize it a bit.
 
 ## [15.2.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-## [15.2.1]
+## [15.3.0]
+
+### Changed
+
+- Return the leading ":" with Gradle project names from gradle-dependencies-q.txt.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Return the leading ":" with Gradle project names from gradle-dependencies-q.txt, and use "0.0.0" for a version instead of "*" since this is a lockfie.
 
-
 ### Added
 
 - Adds a new Bibliothecary::Parsers::Maven.parse_resolved_gradle_dep_line() method for parsing a single line in gradle-dependencies-q.txt, and optimize it a bit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-### Changed
-
-### Removed
+- Adds a new Bibliothecary::Parsers::Maven.parse_resolved_gradle_dep_line() method for parsing a single line in gradle-dependencies-q.txt.
 
 ## [15.2.1]
 

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -195,11 +195,14 @@ module Bibliothecary
       end
 
       def self.parse_gradle_resolved(file_contents, options: {})
+        keep_subprojects = options.fetch(:keep_subprojects_in_maven_tree, false)
+        source = options.fetch(:filename, nil)
         current_type = nil
         project_name = nil
 
         dependencies = file_contents.lines
           .filter_map do |line|
+            line = line.strip
             if project_name.nil? && (project_name_match = GRADLE_PROJECT_REGEXP.match(line))
               project_name = project_name_match.captures[1]
               nil
@@ -207,7 +210,7 @@ module Bibliothecary
               current_type = current_type_match.captures[0] if current_type_match
               nil
             else
-              parse_resolved_gradle_dep_line(line, current_type: current_type, options: options)
+              parse_resolved_gradle_dep_line(line, current_type: current_type, keep_subprojects: keep_subprojects, source: source)
             end
           end
           .uniq { |item| [item.name, item.requirement, item.type, item.original_name, item.original_requirement] }
@@ -218,15 +221,15 @@ module Bibliothecary
         )
       end
 
-      def self.parse_resolved_gradle_dep_line(line, current_type: nil, options: {})
-        return if line.strip.end_with?("(n)") # skip unresolved or already-resolved dependencies
+      def self.parse_resolved_gradle_dep_line(line, current_type: nil, keep_subprojects: false, source: nil)
+        return if line.end_with?("(n)") # skip unresolved or already-resolved dependencies
 
         gradle_dep_match = GRADLE_DEP_REGEXP.match(line)
         return unless gradle_dep_match
 
         # omit Gradle project dependencies
         if (project_match = line.match(GRADLE_DEPENDENCY_PROJECT_REGEXP))
-          return unless options.fetch(:keep_subprojects_in_maven_tree, false)
+          return unless keep_subprojects
 
           # an empty project name is self-referential (i.e. a cycle), and we don't need to track the manifest's
           # project itself, e.g. "+--- project :"
@@ -235,7 +238,7 @@ module Bibliothecary
           sub_project_name = project_match[1]
           # gradle sub-project versions cannot be specified when including them (gradle just uses whichever version is in the
           # codebase), and their versions are 'unspecified' if not set, so just use a wildcard placeholder since it doesn't matter.
-          line = line.sub(GRADLE_DEPENDENCY_PROJECT_REGEXP, ":#{sub_project_name}:*")
+          line = line.sub(project_match[0], ":#{sub_project_name}:*")
         end
 
         cleaned_line = line
@@ -245,8 +248,8 @@ module Bibliothecary
           .strip
 
         # " -> " is either for an aliased dependency, or a version that was resolved from a different requirement or no requirement.
-        if cleaned_line =~ GRADLE_ARROW_REGEXP
-          original_depstring, resolved_depstring = *cleaned_line.split(GRADLE_ARROW_REGEXP, 2)
+        if cleaned_line.include?(" -> ")
+          original_depstring, resolved_depstring = cleaned_line.split(" -> ", 2)
 
           parts = original_depstring.split(":")
           original_name = parts[0..1].join(":") # original at minimum will have a 2-part name
@@ -280,7 +283,7 @@ module Bibliothecary
           name: resolved_name,
           requirement: resolved_requirement,
           type: current_type,
-          source: options.fetch(:filename, nil),
+          source: source,
           platform: platform_name
         )
       end

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -195,89 +195,93 @@ module Bibliothecary
       end
 
       def self.parse_gradle_resolved(file_contents, options: {})
-        keep_subprojects = options.fetch(:keep_subprojects_in_maven_tree, false)
         current_type = nil
         project_name = nil
 
-        dependencies = file_contents.lines.filter_map do |line|
-          next if line.strip.end_with?("(n)") # skip unresolved or already-resolved dependencies
-
-          if project_name.nil? && (project_name_match = GRADLE_PROJECT_REGEXP.match(line))
-            project_name = project_name_match.captures[1]
-            next
-          end
-
-          current_type_match = GRADLE_TYPE_REGEXP.match(line)
-          current_type = current_type_match.captures[0] if current_type_match
-
-          gradle_dep_match = GRADLE_DEP_REGEXP.match(line)
-          next unless gradle_dep_match
-
-          # omit Gradle project dependencies
-          if (project_match = line.match(GRADLE_DEPENDENCY_PROJECT_REGEXP))
-            next unless keep_subprojects
-
-            # an empty project name is self-referential (i.e. a cycle), and we don't need to track the manifest's
-            # project itself, e.g. "+--- project :"
-            next if project_match[1].nil?
-
-            sub_project_name = project_match[1]
-            # gradle sub-project versions cannot be specified when including them (gradle just uses whichever version is in the
-            # codebase), and their versions are 'unspecified' if not set, so just use a wildcard placeholder since it doesn't matter.
-            line = line.sub(GRADLE_DEPENDENCY_PROJECT_REGEXP, ":#{sub_project_name}:*")
-          end
-
-          cleaned_line = line
-            .split(gradle_dep_match.captures[0])[1]
-            .sub(GRADLE_LINE_ENDING_REGEXP, "")
-            .sub(/ FAILED$/, "") # dependency could not be resolved (but still may have a version)
-            .strip
-
-          # " -> " is either for an aliased dependency, or a version that was resolved from a different requirement or no requirement.
-          if cleaned_line =~ GRADLE_ARROW_REGEXP
-            original_depstring, resolved_depstring = *cleaned_line.split(GRADLE_ARROW_REGEXP, 2)
-
-            parts = original_depstring.split(":")
-            original_name = parts[0..1].join(":") # original at minimum will have a 2-part name
-            original_requirement = parts[2] || "*"
-
-            parts = resolved_depstring.split(":")
-            resolved_requirement = parts.pop # resolved at minimum will have a 1-part version
-            resolved_name = parts.join(":")
-
-            # this case is not an actual alias, just a different version was resolved, so won't keep track of original
-            if resolved_name.empty? && !original_name.empty?
-              resolved_name = original_name
-              original_name = nil
-              original_requirement = nil
+        dependencies = file_contents.lines
+          .filter_map do |line|
+            if project_name.nil? && (project_name_match = GRADLE_PROJECT_REGEXP.match(line))
+              project_name = project_name_match.captures[1]
+              nil
+            elsif (current_type_match = GRADLE_TYPE_REGEXP.match(line))
+              current_type = current_type_match.captures[0] if current_type_match
+              nil
+            else
+              parse_resolved_gradle_dep_line(line, current_type: current_type, options: options)
             end
-          else
-            original_name = nil
-            original_requirement = nil
-
-            # handle simple resolved dep
-            parts = cleaned_line.split(":")
-            next if parts.size < 3 # we didn't get a full name and version, so skip it
-
-            resolved_requirement = parts.pop
-            resolved_name = parts.join(":")
           end
-
-          Dependency.new(
-            original_name: original_name,
-            original_requirement: original_requirement,
-            name: resolved_name,
-            requirement: resolved_requirement,
-            type: current_type,
-            source: options.fetch(:filename, nil),
-            platform: platform_name
-          )
-        end
           .uniq { |item| [item.name, item.requirement, item.type, item.original_name, item.original_requirement] }
 
         ParserResult.new(
           project_name: project_name,
           dependencies: dependencies
+        )
+      end
+
+      def self.parse_resolved_gradle_dep_line(line, current_type: nil, options: {})
+        return if line.strip.end_with?("(n)") # skip unresolved or already-resolved dependencies
+
+        gradle_dep_match = GRADLE_DEP_REGEXP.match(line)
+        return unless gradle_dep_match
+
+        # omit Gradle project dependencies
+        if (project_match = line.match(GRADLE_DEPENDENCY_PROJECT_REGEXP))
+          return unless options.fetch(:keep_subprojects_in_maven_tree, false)
+
+          # an empty project name is self-referential (i.e. a cycle), and we don't need to track the manifest's
+          # project itself, e.g. "+--- project :"
+          return if project_match[1].nil?
+
+          sub_project_name = project_match[1]
+          # gradle sub-project versions cannot be specified when including them (gradle just uses whichever version is in the
+          # codebase), and their versions are 'unspecified' if not set, so just use a wildcard placeholder since it doesn't matter.
+          line = line.sub(GRADLE_DEPENDENCY_PROJECT_REGEXP, ":#{sub_project_name}:*")
+        end
+
+        cleaned_line = line
+          .split(gradle_dep_match.captures[0])[1]
+          .sub(GRADLE_LINE_ENDING_REGEXP, "")
+          .sub(/ FAILED$/, "") # dependency could not be resolved (but still may have a version)
+          .strip
+
+        # " -> " is either for an aliased dependency, or a version that was resolved from a different requirement or no requirement.
+        if cleaned_line =~ GRADLE_ARROW_REGEXP
+          original_depstring, resolved_depstring = *cleaned_line.split(GRADLE_ARROW_REGEXP, 2)
+
+          parts = original_depstring.split(":")
+          original_name = parts[0..1].join(":") # original at minimum will have a 2-part name
+          original_requirement = parts[2] || "*"
+
+          parts = resolved_depstring.split(":")
+          resolved_requirement = parts.pop # resolved at minimum will have a 1-part version
+          resolved_name = parts.join(":")
+
+          # this case is not an actual alias, just a different version was resolved, so won't keep track of original
+          if resolved_name.empty? && !original_name.empty?
+            resolved_name = original_name
+            original_name = nil
+            original_requirement = nil
+          end
+        else
+          original_name = nil
+          original_requirement = nil
+
+          # handle simple resolved dep
+          parts = cleaned_line.split(":")
+          return if parts.size < 3 # we didn't get a full name and version, so skip it
+
+          resolved_requirement = parts.pop
+          resolved_name = parts.join(":")
+        end
+
+        Dependency.new(
+          original_name: original_name,
+          original_requirement: original_requirement,
+          name: resolved_name,
+          requirement: resolved_requirement,
+          type: current_type,
+          source: options.fetch(:filename, nil),
+          platform: platform_name
         )
       end
 

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -24,12 +24,12 @@ module Bibliothecary
       GRADLE_ARROW_REGEXP = / -> /
 
       # The name of the project containing the given dependencies
-      GRADLE_PROJECT_REGEXP = /\s*(Root p|P)roject '?:?([^\s']+)'?/
+      GRADLE_PROJECT_REGEXP = /\s*(Root p|P)roject '?(:?[^\s']+)'?/
 
       # Dependencies that are on-disk projects, eg:
       # e.g. "\--- project :api:my-internal-project"
       # e.g. "+--- my-group:my-alias:1.2.3 -> project :client (*)"
-      GRADLE_DEPENDENCY_PROJECT_REGEXP = /project :?(\S+)?/
+      GRADLE_DEPENDENCY_PROJECT_REGEXP = /project (:?\S+)?/
 
       # line ending legend: (c) means a dependency constraint, (n) means not resolved, or (*) means resolved previously, e.g. org.springframework.boot:spring-boot-starter-web:2.1.0.M3 (*)
       # e.g. the "(n)" in "+--- my-group:my-name:1.2.3 (n)"
@@ -238,7 +238,7 @@ module Bibliothecary
           sub_project_name = project_match[1]
           # gradle sub-project versions cannot be specified when including them (gradle just uses whichever version is in the
           # codebase), and their versions are 'unspecified' if not set, so just use a wildcard placeholder since it doesn't matter.
-          line = line.sub(project_match[0], ":#{sub_project_name}:*")
+          line = line.sub(project_match[0], "#{sub_project_name}:*")
         end
 
         cleaned_line = line

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -237,8 +237,8 @@ module Bibliothecary
 
           sub_project_name = project_match[1]
           # gradle sub-project versions cannot be specified when including them (gradle just uses whichever version is in the
-          # codebase), and their versions are 'unspecified' if not set, so just use a wildcard placeholder since it doesn't matter.
-          line = line.sub(project_match[0], "#{sub_project_name}:*")
+          # codebase), and their versions are 'unspecified' if not set, so just use a placeholder version since it doesn't matter.
+          line = line.sub(project_match[0], "#{sub_project_name}:0.0.0")
         end
 
         cleaned_line = line

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bibliothecary
-  VERSION = "15.2.1"
+  VERSION = "15.3.0"
 end

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -734,7 +734,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
       GRADLE
 
       expect(described_class.parse_gradle_resolved(gradle_dependencies_out)).to eq Bibliothecary::ParserResult.new(
-        project_name: "submodules:test",
+        project_name: ":submodules:test",
         dependencies: []
       )
     end
@@ -859,7 +859,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
       expect(results).to eq({
                               parser: "maven",
                               path: "gradle-dependencies-q.txt",
-                              project_name: "utilities",
+                              project_name: ":utilities",
                               kind: "lockfile",
                               success: true,
                               dependencies: [

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -664,7 +664,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
                    Bibliothecary::Dependency.new(
                      platform: "maven",
                      name: ":acme:my-internal-project",
-                     requirement: "*",
+                     requirement: "0.0.0",
                      type: nil
                    ),
                ]
@@ -687,7 +687,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
                    Bibliothecary::Dependency.new(
                      platform: "maven",
                      name: ":client",
-                     requirement: "*",
+                     requirement: "0.0.0",
                      original_name: "my-group:common-job-update-gateway-compress",
                      original_requirement: "5.0.2",
                      type: nil
@@ -863,9 +863,9 @@ RSpec.describe Bibliothecary::Parsers::Maven do
                               kind: "lockfile",
                               success: true,
                               dependencies: [
-          Bibliothecary::Dependency.new(name: ":list", requirement: "*", type: "compileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
+          Bibliothecary::Dependency.new(name: ":list", requirement: "0.0.0", type: "compileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "org.fusesource.jansi:jansi", requirement: "2.4.1", type: "compileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
-          Bibliothecary::Dependency.new(name: ":list", requirement: "*", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
+          Bibliothecary::Dependency.new(name: ":list", requirement: "0.0.0", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "com.google.guava:guava", requirement: "33.0.0-jre", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "com.google.guava:failureaccess", requirement: "1.0.2", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "com.google.guava:listenablefuture", requirement: "9999.0-empty-to-avoid-conflict-with-guava", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
@@ -873,7 +873,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
           Bibliothecary::Dependency.new(name: "org.checkerframework:checker-qual", requirement: "3.41.0", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "com.google.errorprone:error_prone_annotations", requirement: "2.23.0", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "org.fusesource.jansi:jansi", requirement: "2.4.1", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
-          Bibliothecary::Dependency.new(name: ":list", requirement: "*", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
+          Bibliothecary::Dependency.new(name: ":list", requirement: "0.0.0", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "org.fusesource.jansi:jansi", requirement: "2.4.1", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "org.junit.jupiter:junit-jupiter", requirement: "5.12.1", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "org.junit:junit-bom", requirement: "5.12.1", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
@@ -882,7 +882,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
           Bibliothecary::Dependency.new(name: "org.junit.platform:junit-platform-commons", requirement: "1.12.1", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "org.opentest4j:opentest4j", requirement: "1.3.0", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "org.apiguardian:apiguardian-api", requirement: "1.1.2", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
-          Bibliothecary::Dependency.new(name: ":list", requirement: "*", type: "testRuntimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
+          Bibliothecary::Dependency.new(name: ":list", requirement: "0.0.0", type: "testRuntimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "com.google.guava:guava", requirement: "33.0.0-jre", type: "testRuntimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "com.google.guava:failureaccess", requirement: "1.0.2", type: "testRuntimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "com.google.guava:listenablefuture", requirement: "9999.0-empty-to-avoid-conflict-with-guava", type: "testRuntimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),


### PR DESCRIPTION
Changes: 

* extracts a `parse_resolved_gradle_dep_line()` method 
* some micro-optimizations to reduce Regexp/String allocations
* return the leading ":" from Gradle project names (as "project_name" **and** as deps in the file), and use "0.0.0" as the subproject placeholder version instead of "*"