### PR TITLE
Prefer component version field over purl version in CycloneDX parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [15.2.1]
+
+### Changed
+
+- Prefer component version field over purl version in CycloneDX parser.
+
 ## [15.2.0]
 
 ### Changed

--- a/lib/bibliothecary/multi_parsers/cyclonedx.rb
+++ b/lib/bibliothecary/multi_parsers/cyclonedx.rb
@@ -30,13 +30,13 @@ module Bibliothecary
           @parse_queue = parse_queue.dup
         end
 
-        def add(purl, source = nil)
+        def add(purl, version = nil, source = nil)
           # Use the mapped purl->bibliothecary platform, or else fall back to original platform itself.
           mapping = PurlUtil::PURL_TYPE_MAPPING.fetch(purl.type, purl.type)
 
           @entries << Dependency.new(
             name: PurlUtil.full_name(purl),
-            requirement: purl.version,
+            requirement: version || purl.version,
             platform: mapping ? mapping.to_s : purl.type,
             type: "lockfile",
             source: source
@@ -45,18 +45,28 @@ module Bibliothecary
 
         # Iterates over each manifest entry in the parse_queue, and accepts a block which will
         # be called on each component. The block has two jobs: 1) add more sub-components
-        # to parse (if they exist), and 2) return the components purl.
+        # to parse (if they exist), and 2) return the components purl and version.
         def parse!(source = nil, &block)
           until @parse_queue.empty?
             component = @parse_queue.shift
 
-            purl_text = block.call(component, @parse_queue)
+            result = block.call(component, @parse_queue)
+
+            next unless result
+
+            if result.is_a?(Hash)
+              purl_text = result[:purl]
+              version = result[:version]
+            else
+              purl_text = result
+              version = nil
+            end
 
             next unless purl_text
 
             purl = PackageURL.parse(purl_text)
 
-            add(purl, source)
+            add(purl, version, source)
           end
         end
       end
@@ -104,7 +114,7 @@ module Bibliothecary
         manifest_entries.parse!(options.fetch(:filename, nil)) do |component, parse_queue|
           parse_queue.concat(component["components"]) if component["components"]
 
-          component["purl"]
+          { purl: component["purl"], version: component["version"] }
         end
 
         ParserResult.new(dependencies: manifest_entries.entries.to_a)
@@ -131,7 +141,10 @@ module Bibliothecary
           # always safely concatenate it to the parse queue.
           parse_queue.concat(component.locate("components/*"))
 
-          component.locate("purl").first&.text
+          purl_text = component.locate("purl").first&.text
+          version = component.locate("version").first&.text
+
+          { purl: purl_text, version: version }
         end
 
         ParserResult.new(dependencies: manifest_entries.entries.to_a)

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bibliothecary
-  VERSION = "15.2.0"
+  VERSION = "15.2.1"
 end

--- a/spec/fixtures/cyclonedx-nested.json
+++ b/spec/fixtures/cyclonedx-nested.json
@@ -7,16 +7,19 @@
         {
           "type": "library",
           "name": "1to2",
+          "version": "1.0.0",
           "purl": "pkg:npm/1to2@1.0.0",
           "components": [
             {
               "type": "library",
               "name": "go",
+              "version": "v0.38.0",
               "purl": "pkg:golang/cloud.google.com/go@v0.38.0",
               "components": [
                 {
                   "type": "library",
                   "name": "HdrHistogram",
+                  "version": "2.1.9",
                   "purl": "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.9"
                 }
               ]

--- a/spec/fixtures/cyclonedx-nested.xml
+++ b/spec/fixtures/cyclonedx-nested.xml
@@ -6,14 +6,17 @@
       <components>
         <component type="library">
           <name>1to2</name>
+          <version>1.0.0</version>
           <purl>pkg:npm/1to2@1.0.0</purl>
           <components>
             <component type="library">
               <name>go</name>
+              <version>v0.38.0</version>
               <purl>pkg:golang/cloud.google.com/go@v0.38.0</purl>
               <components>
                 <component type="library">
                   <name>HdrHistogram</name>
+                  <version>2.1.9</version>
                   <purl>pkg:maven/org.hdrhistogram/HdrHistogram@2.1.9</purl>
                 </component>
               </components>

--- a/spec/fixtures/cyclonedx.json
+++ b/spec/fixtures/cyclonedx.json
@@ -21,6 +21,14 @@
   },
   "components": [
     {
+      "type": "library",
+      "bom-ref": "pkg:rpm/redhat/nginx-core@1.26.3-1.el10?arch=x86_64&distro=redhat-10.1&epoch=2",
+      "name": "nginx-core",
+      "version": "2:1.26.3-1.el10",
+      "licenses": [{ "license": { "id": "BSD-2-Clause" } }],
+      "purl": "pkg:rpm/redhat/nginx-core@1.26.3-1.el10?arch=x86_64&distro=redhat-10.1&epoch=2"
+    },
+    {
       "bom-ref": "pkg:golang/../access-go-client?syft-id=7911d0d6beeef730",
       "type": "library",
       "name": "../access-go-client",

--- a/spec/multi_parsers/cyclonedx_spec.rb
+++ b/spec/multi_parsers/cyclonedx_spec.rb
@@ -6,6 +6,8 @@ describe Bibliothecary::MultiParsers::CycloneDX do
   let(:unmapped_component) { "pkg:deb/debian/krita@5.0.5" }
 
   it "matches json filenames" do
+    input = '{ "components": [] }'
+
     %w[
       cyclonedx.json
       cycloneDX.JSON
@@ -16,12 +18,14 @@ describe Bibliothecary::MultiParsers::CycloneDX do
       as-a-suffix-cdx.json
       as-a-suffix-CDX.json
     ].each do |filename|
-      result = described_class.analyse_contents(filename, '{ "components": [] }')
+      result = described_class.analyse_contents(filename, input)
       expect(result[:success]).to eq(true), "#{filename} should match but did not."
     end
   end
 
   it "matches xml filenames" do
+    input = '<?xml version="1.0" encoding="UTF-8"?><bom xmlns="http://cyclonedx.org/schema/bom/1.4"><components></components></bom>'
+
     %w[
       cyclonedx.xml
       cycloneDX.XML
@@ -32,61 +36,85 @@ describe Bibliothecary::MultiParsers::CycloneDX do
       as-a-suffix-cdx.xml
       as-a-suffix-CDX.XML
     ].each do |filename|
-      result = described_class.analyse_contents(filename, '<?xml version="1.0" encoding="UTF-8"?><bom xmlns="http://cyclonedx.org/schema/bom/1.4"><components></components></bom>')
+      result = described_class.analyse_contents(filename, input)
       expect(result[:success]).to eq(true), "#{filename} should match but did not."
     end
   end
 
   it "handles malformed json" do
-    expect { described_class.parse_cyclonedx_json("{}") }.to raise_error(described_class::NoComponents)
+    input = "{}"
+
+    expect { described_class.parse_cyclonedx_json(input) }.to raise_error(described_class::NoComponents)
   end
 
   it "handles malformed xml" do
-    expect { described_class.parse_cyclonedx_xml('<?xml version="1.0" encoding="UTF-8"?><bom xmlns="http://cyclonedx.org/schema/bom/1.4"></bom>') }.to raise_error(described_class::NoComponents)
+    input = '<?xml version="1.0" encoding="UTF-8"?><bom xmlns="http://cyclonedx.org/schema/bom/1.4"></bom>'
+
+    expect { described_class.parse_cyclonedx_xml(input) }.to raise_error(described_class::NoComponents)
   end
 
   it "handles empty json components" do
-    expect(described_class.parse_cyclonedx_json('{ "components": [] }')).to eq(Bibliothecary::ParserResult.new(dependencies: []))
+    input = '{ "components": [] }'
+
+    expect(described_class.parse_cyclonedx_json(input)).to eq(
+      Bibliothecary::ParserResult.new(dependencies: [])
+    )
   end
 
   it "handles empty xml components" do
-    expect(described_class.parse_cyclonedx_xml('<?xml version="1.0" encoding="UTF-8"?><bom xmlns="http://cyclonedx.org/schema/bom/1.4"><components></components></bom>')).to eq(Bibliothecary::ParserResult.new(dependencies: []))
+    input = '<?xml version="1.0" encoding="UTF-8"?><bom xmlns="http://cyclonedx.org/schema/bom/1.4"><components></components></bom>'
+
+    expect(described_class.parse_cyclonedx_xml(input)).to eq(
+      Bibliothecary::ParserResult.new(dependencies: [])
+    )
   end
 
   it "handles unmapped json component" do
-    expect(described_class.parse_cyclonedx_json(%({ "components": [{ "purl": "#{unmapped_component}" }] }), options: { filename: "test-full-sbom.json" })).to eq(Bibliothecary::ParserResult.new(dependencies: [
-      Bibliothecary::Dependency.new(
-        platform: "deb",
-        name: "debian/krita",
-        requirement: "5.0.5",
-        type: "lockfile",
-        source: "test-full-sbom.json"
-      ),
-    ]))
+    input = %({ "components": [{ "purl": "#{unmapped_component}" }] })
+
+    expect(described_class.parse_cyclonedx_json(input, options: { filename: "test-full-sbom.json" })).to eq(
+      Bibliothecary::ParserResult.new(dependencies: [
+            Bibliothecary::Dependency.new(
+              platform: "deb",
+              name: "debian/krita",
+              requirement: "5.0.5",
+              type: "lockfile",
+              source: "test-full-sbom.json"
+            ),
+          ])
+    )
   end
 
   it "handles unmapped xml component" do
-    expect(described_class.parse_cyclonedx_xml(%(<?xml version="1.0" encoding="UTF-8"?><bom xmlns="http://cyclonedx.org/schema/bom/1.4"><components><component><purl>#{unmapped_component}</purl></component></components></bom>), options: { filename: "cyclonedx.xml" })).to eq(Bibliothecary::ParserResult.new(dependencies: [
-      Bibliothecary::Dependency.new(
-        platform: "deb",
-        name: "debian/krita",
-        requirement: "5.0.5",
-        type: "lockfile",
-        source: "cyclonedx.xml"
-      ),
-    ]))
+    input = %(<?xml version="1.0" encoding="UTF-8"?><bom xmlns="http://cyclonedx.org/schema/bom/1.4"><components><component><purl>#{unmapped_component}</purl></component></components></bom>)
+
+    expect(described_class.parse_cyclonedx_xml(input, options: { filename: "cyclonedx.xml" })).to eq(
+      Bibliothecary::ParserResult.new(dependencies: [
+            Bibliothecary::Dependency.new(
+              platform: "deb",
+              name: "debian/krita",
+              requirement: "5.0.5",
+              type: "lockfile",
+              source: "cyclonedx.xml"
+            ),
+          ])
+    )
   end
 
   it "handles no xml pragma" do
-    expect(described_class.parse_cyclonedx_xml(%(<bom xmlns="http://cyclonedx.org/schema/bom/1.4"><components><component><purl>#{unmapped_component}</purl></component></components></bom>), options: { filename: "cyclonedx.xml" })).to eq(Bibliothecary::ParserResult.new(dependencies: [
-      Bibliothecary::Dependency.new(
-        platform: "deb",
-        name: "debian/krita",
-        requirement: "5.0.5",
-        type: "lockfile",
-        source: "cyclonedx.xml"
-      ),
-    ]))
+    input = %(<bom xmlns="http://cyclonedx.org/schema/bom/1.4"><components><component><purl>#{unmapped_component}</purl></component></components></bom>)
+
+    expect(described_class.parse_cyclonedx_xml(input, options: { filename: "cyclonedx.xml" })).to eq(
+      Bibliothecary::ParserResult.new(dependencies: [
+            Bibliothecary::Dependency.new(
+              platform: "deb",
+              name: "debian/krita",
+              requirement: "5.0.5",
+              type: "lockfile",
+              source: "cyclonedx.xml"
+            ),
+          ])
+    )
   end
 
   describe "ManifestEntries#parse!" do
@@ -108,83 +136,102 @@ describe Bibliothecary::MultiParsers::CycloneDX do
   end
 
   it "handles empty json components" do
-    expect(described_class.analyse_contents("cyclonedx.json", '{ "components": [] }')).to eq({
-                                                                                               parser: "cyclonedx",
-                                                                                               path: "cyclonedx.json",
-                                                                                               project_name: nil,
-                                                                                               dependencies: [],
-                                                                                               kind: "lockfile",
-                                                                                               success: true,
-                                                                                             })
+    input = '{ "components": [] }'
+
+    expect(described_class.analyse_contents("cyclonedx.json", input)).to eq(
+      {
+        parser: "cyclonedx",
+        path: "cyclonedx.json",
+        project_name: nil,
+        dependencies: [],
+        kind: "lockfile",
+        success: true,
+      }
+    )
   end
 
   it "handles empty xml components" do
-    expect(described_class.analyse_contents("cyclonedx.xml", '<?xml version="1.0" encoding="UTF-8"?><bom xmlns="http://cyclonedx.org/schema/bom/1.4"><components></components></bom>')).to eq({
-                                                                                                                                                                                                parser: "cyclonedx",
-                                                                                                                                                                                                path: "cyclonedx.xml",
-                                                                                                                                                                                                project_name: nil,
-                                                                                                                                                                                                dependencies: [],
-                                                                                                                                                                                                kind: "lockfile",
-                                                                                                                                                                                                success: true,
-                                                                                                                                                                                              })
+    input = '<?xml version="1.0" encoding="UTF-8"?><bom xmlns="http://cyclonedx.org/schema/bom/1.4"><components></components></bom>'
+
+    expect(described_class.analyse_contents("cyclonedx.xml", input)).to eq(
+      {
+        parser: "cyclonedx",
+        path: "cyclonedx.xml",
+        project_name: nil,
+        dependencies: [],
+        kind: "lockfile",
+        success: true,
+      }
+    )
   end
 
   it "handles unmapped json component" do
-    expect(described_class.analyse_contents("cyclonedx.json", %({ "components": [{ "purl": "#{unmapped_component}" }] }))).to eq({
-                                                                                                                                   parser: "cyclonedx",
-                                                                                                                                   path: "cyclonedx.json",
-                                                                                                                                   project_name: nil,
-                                                                                                                                   dependencies: [
-                                                                                                                                    Bibliothecary::Dependency.new(
-                                                                                                                                      platform: "deb",
-                                                                                                                                      name: "debian/krita",
-                                                                                                                                      requirement: "5.0.5",
-                                                                                                                                      type: "lockfile",
-                                                                                                                                      source: "cyclonedx.json"
-                                                                                                                                    ),
-                                                                                                                                   ],
-                                                                                                                                   kind: "lockfile",
-                                                                                                                                   success: true,
-                                                                                                                                 })
+    input = %({ "components": [{ "purl": "#{unmapped_component}" }] })
+
+    expect(described_class.analyse_contents("cyclonedx.json", input)).to eq(
+      {
+        parser: "cyclonedx",
+        path: "cyclonedx.json",
+        project_name: nil,
+        dependencies: [
+          Bibliothecary::Dependency.new(
+            platform: "deb",
+            name: "debian/krita",
+            requirement: "5.0.5",
+            type: "lockfile",
+            source: "cyclonedx.json"
+          ),
+        ],
+        kind: "lockfile",
+        success: true,
+      }
+    )
   end
 
   it "handles unmapped xml component" do
-    expect(described_class.analyse_contents("cyclonedx.xml", %(<?xml version="1.0" encoding="UTF-8"?><bom xmlns="http://cyclonedx.org/schema/bom/1.4"><components><component><purl>#{unmapped_component}</purl></component></components></bom>))).to eq({
-                                                                                                                                                                                                                                                          parser: "cyclonedx",
-                                                                                                                                                                                                                                                          path: "cyclonedx.xml",
-                                                                                                                                                                                                                                                          project_name: nil,
-                                                                                                                                                                                                                                                          dependencies: [
-                                                                                                                                                                                                                                                            Bibliothecary::Dependency.new(
-                                                                                                                                                                                                                                                              platform: "deb",
-                                                                                                                                                                                                                                                              name: "debian/krita",
-                                                                                                                                                                                                                                                              requirement: "5.0.5",
-                                                                                                                                                                                                                                                              type: "lockfile",
-                                                                                                                                                                                                                                                              source: "cyclonedx.xml"
-                                                                                                                                                                                                                                                            ),
+    input = %(<?xml version="1.0" encoding="UTF-8"?><bom xmlns="http://cyclonedx.org/schema/bom/1.4"><components><component><purl>#{unmapped_component}</purl></component></components></bom>)
 
-                                                                                                                                                                                                                                                          ],
-                                                                                                                                                                                                                                                          kind: "lockfile",
-                                                                                                                                                                                                                                                          success: true,
-                                                                                                                                                                                                                                                        })
+    expect(described_class.analyse_contents("cyclonedx.xml", input)).to eq(
+      {
+        parser: "cyclonedx",
+        path: "cyclonedx.xml",
+        project_name: nil,
+        dependencies: [
+          Bibliothecary::Dependency.new(
+            platform: "deb",
+            name: "debian/krita",
+            requirement: "5.0.5",
+            type: "lockfile",
+            source: "cyclonedx.xml"
+          ),
+        ],
+        kind: "lockfile",
+        success: true,
+      }
+    )
   end
 
   it "handles no xml pragma" do
-    expect(described_class.analyse_contents("cyclonedx.xml", %(<bom xmlns="http://cyclonedx.org/schema/bom/1.4"><components><component><purl>#{unmapped_component}</purl></component></components></bom>))).to eq({
-                                                                                                                                                                                                                    parser: "cyclonedx",
-                                                                                                                                                                                                                    path: "cyclonedx.xml",
-                                                                                                                                                                                                                    project_name: nil,
-                                                                                                                                                                                                                    dependencies: [
-                                                                                                                                                                                                                      Bibliothecary::Dependency.new(
-                                                                                                                                                                                                                        platform: "deb",
-                                                                                                                                                                                                                        name: "debian/krita",
-                                                                                                                                                                                                                        requirement: "5.0.5",
-                                                                                                                                                                                                                        type: "lockfile",
-                                                                                                                                                                                                                        source: "cyclonedx.xml"
-                                                                                                                                                                                                                      ),
-                                                                                                                                                                                                                    ],
-                                                                                                                                                                                                                    kind: "lockfile",
-                                                                                                                                                                                                                    success: true,
-                                                                                                                                                                                                                  })
+    input = %(<bom xmlns="http://cyclonedx.org/schema/bom/1.4"><components><component><purl>#{unmapped_component}</purl></component></components></bom>)
+
+    expect(described_class.analyse_contents("cyclonedx.xml", input)).to eq(
+      {
+        parser: "cyclonedx",
+        path: "cyclonedx.xml",
+        project_name: nil,
+        dependencies: [
+        Bibliothecary::Dependency.new(
+          platform: "deb",
+          name: "debian/krita",
+          requirement: "5.0.5",
+          type: "lockfile",
+          source: "cyclonedx.xml"
+        ),
+],
+        kind: "lockfile",
+        success: true,
+      }
+    )
   end
 
   describe "ManifestEntries#parse!" do
@@ -233,13 +280,15 @@ describe Bibliothecary::MultiParsers::CycloneDX do
     result = described_class.analyse_contents("cyclonedx.json", load_fixture("cyclonedx.json"))
 
     artifactory_dependencies.each do |dependency|
-      expect(result[:dependencies].find { |d| d.name == dependency[:name] }).to eq(Bibliothecary::Dependency.new(
-                                                                                     platform: dependency[:platform].to_s,
-                                                                                     name: dependency[:name],
-                                                                                     requirement: dependency[:version],
-                                                                                     type: "lockfile",
-                                                                                     source: "cyclonedx.json"
-                                                                                   ))
+      expect(result[:dependencies].find { |d| d.name == dependency[:name] }).to eq(
+        Bibliothecary::Dependency.new(
+          platform: dependency[:platform].to_s,
+          name: dependency[:name],
+          requirement: dependency[:version],
+          type: "lockfile",
+          source: "cyclonedx.json"
+        )
+      )
     end
   end
 
@@ -247,13 +296,15 @@ describe Bibliothecary::MultiParsers::CycloneDX do
     result = described_class.analyse_contents("cyclonedx.json", load_fixture("cyclonedx-nested.json"))
 
     artifactory_dependencies.each do |dependency|
-      expect(result[:dependencies].find { |d| d.name == dependency[:name] }).to eq(Bibliothecary::Dependency.new(
-                                                                                     platform: dependency[:platform].to_s,
-                                                                                     name: dependency[:name],
-                                                                                     requirement: dependency[:version],
-                                                                                     type: "lockfile",
-                                                                                     source: "cyclonedx.json"
-                                                                                   ))
+      expect(result[:dependencies].find { |d| d.name == dependency[:name] }).to eq(
+        Bibliothecary::Dependency.new(
+          platform: dependency[:platform].to_s,
+          name: dependency[:name],
+          requirement: dependency[:version],
+          type: "lockfile",
+          source: "cyclonedx.json"
+        )
+      )
     end
   end
 
@@ -261,13 +312,15 @@ describe Bibliothecary::MultiParsers::CycloneDX do
     result = described_class.analyse_contents("cyclonedx.xml", load_fixture("cyclonedx.xml"))
 
     artifactory_dependencies.each do |dependency|
-      expect(result[:dependencies].find { |d| d.name == dependency[:name] }).to eq(Bibliothecary::Dependency.new(
-                                                                                     platform: dependency[:platform].to_s,
-                                                                                     name: dependency[:name],
-                                                                                     requirement: dependency[:version],
-                                                                                     type: "lockfile",
-                                                                                     source: "cyclonedx.xml"
-                                                                                   ))
+      expect(result[:dependencies].find { |d| d.name == dependency[:name] }).to eq(
+        Bibliothecary::Dependency.new(
+          platform: dependency[:platform].to_s,
+          name: dependency[:name],
+          requirement: dependency[:version],
+          type: "lockfile",
+          source: "cyclonedx.xml"
+        )
+      )
     end
   end
 
@@ -275,13 +328,15 @@ describe Bibliothecary::MultiParsers::CycloneDX do
     result = described_class.analyse_contents("cyclonedx.xml", load_fixture("cyclonedx-nested.xml"))
 
     artifactory_dependencies.each do |dependency|
-      expect(result[:dependencies].find { |d| d.name == dependency[:name] }).to eq(Bibliothecary::Dependency.new(
-                                                                                     platform: dependency[:platform].to_s,
-                                                                                     name: dependency[:name],
-                                                                                     requirement: dependency[:version],
-                                                                                     type: "lockfile",
-                                                                                     source: "cyclonedx.xml"
-                                                                                   ))
+      expect(result[:dependencies].find { |d| d.name == dependency[:name] }).to eq(
+        Bibliothecary::Dependency.new(
+          platform: dependency[:platform].to_s,
+          name: dependency[:name],
+          requirement: dependency[:version],
+          type: "lockfile",
+          source: "cyclonedx.xml"
+        )
+      )
     end
   end
 

--- a/spec/multi_parsers/cyclonedx_spec.rb
+++ b/spec/multi_parsers/cyclonedx_spec.rb
@@ -86,7 +86,7 @@ describe Bibliothecary::MultiParsers::CycloneDX do
   end
 
   it "handles unmapped xml component" do
-    input = %(<?xml version="1.0" encoding="UTF-8"?><bom xmlns="http://cyclonedx.org/schema/bom/1.4"><components><component><purl>#{unmapped_component}</purl></component></components></bom>)
+    input = %(<?xml version="1.0" encoding="UTF-8"?><bom xmlns="http://cyclonedx.org/schema/bom/1.4"><components><component><purl>#{unmapped_component}</purl><version>5.0.5</version></component></components></bom>)
 
     expect(described_class.parse_cyclonedx_xml(input, options: { filename: "cyclonedx.xml" })).to eq(
       Bibliothecary::ParserResult.new(dependencies: [
@@ -102,7 +102,7 @@ describe Bibliothecary::MultiParsers::CycloneDX do
   end
 
   it "handles no xml pragma" do
-    input = %(<bom xmlns="http://cyclonedx.org/schema/bom/1.4"><components><component><purl>#{unmapped_component}</purl></component></components></bom>)
+    input = %(<bom xmlns="http://cyclonedx.org/schema/bom/1.4"><components><component><purl>#{unmapped_component}</purl><version>5.0.5</version></component></components></bom>)
 
     expect(described_class.parse_cyclonedx_xml(input, options: { filename: "cyclonedx.xml" })).to eq(
       Bibliothecary::ParserResult.new(dependencies: [
@@ -166,7 +166,7 @@ describe Bibliothecary::MultiParsers::CycloneDX do
   end
 
   it "handles unmapped json component" do
-    input = %({ "components": [{ "purl": "#{unmapped_component}" }] })
+    input = %({ "components": [{ "purl": "#{unmapped_component}", "version": "5.0.5" }] })
 
     expect(described_class.analyse_contents("cyclonedx.json", input)).to eq(
       {
@@ -189,7 +189,7 @@ describe Bibliothecary::MultiParsers::CycloneDX do
   end
 
   it "handles unmapped xml component" do
-    input = %(<?xml version="1.0" encoding="UTF-8"?><bom xmlns="http://cyclonedx.org/schema/bom/1.4"><components><component><purl>#{unmapped_component}</purl></component></components></bom>)
+    input = %(<?xml version="1.0" encoding="UTF-8"?><bom xmlns="http://cyclonedx.org/schema/bom/1.4"><components><component><purl>#{unmapped_component}</purl><version>5.0.5</version></component></components></bom>)
 
     expect(described_class.analyse_contents("cyclonedx.xml", input)).to eq(
       {
@@ -212,7 +212,7 @@ describe Bibliothecary::MultiParsers::CycloneDX do
   end
 
   it "handles no xml pragma" do
-    input = %(<bom xmlns="http://cyclonedx.org/schema/bom/1.4"><components><component><purl>#{unmapped_component}</purl></component></components></bom>)
+    input = %(<bom xmlns="http://cyclonedx.org/schema/bom/1.4"><components><component><purl>#{unmapped_component}</purl><version>5.0.5</version></component></components></bom>)
 
     expect(described_class.analyse_contents("cyclonedx.xml", input)).to eq(
       {


### PR DESCRIPTION
Update the CycloneDX parser to use the component's version field as the primary source for dependency versions, falling back to the purl version when not present. This handles packages like RPM that include the epoch information in the version field (e.g., "2:1.26.3-1.el10") which differs from the version in the purl.

The first commit is just some formatting to make the specs a bit more readable.