### PR TITLE
[15.3.1] Prefix subproject names in gradle-dependencies-q.txt with "subproject"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [15.3.1]
+
+### Changed
+
+- Return a leading "subproject" prefix with Gradle project names from gradle-dependencies-q.txt too.
+
 ## [15.3.0]
 
 ### Changed

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -205,6 +205,8 @@ module Bibliothecary
             line = line.strip
             if project_name.nil? && (project_name_match = GRADLE_PROJECT_REGEXP.match(line))
               project_name = project_name_match.captures[1]
+              project_name = ":#{project_name}" unless project_name.start_with?(":")
+              project_name = "subproject#{project_name}"
               nil
             elsif (current_type_match = GRADLE_TYPE_REGEXP.match(line))
               current_type = current_type_match.captures[0] if current_type_match
@@ -238,7 +240,8 @@ module Bibliothecary
           sub_project_name = project_match[1]
           # gradle sub-project versions cannot be specified when including them (gradle just uses whichever version is in the
           # codebase), and their versions are 'unspecified' if not set, so just use a placeholder version since it doesn't matter.
-          line = line.sub(project_match[0], "#{sub_project_name}:0.0.0")
+          # the name also doesn't include a project, so we use "subproject:" prefix to denote that these are subproject deps.
+          line = line.sub(project_match[0], "subproject#{sub_project_name}:0.0.0")
         end
 
         cleaned_line = line

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bibliothecary
-  VERSION = "15.3.0"
+  VERSION = "15.3.1"
 end

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -663,7 +663,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
                  dependencies: [
                    Bibliothecary::Dependency.new(
                      platform: "maven",
-                     name: ":acme:my-internal-project",
+                     name: "subproject:acme:my-internal-project",
                      requirement: "0.0.0",
                      type: nil
                    ),
@@ -686,7 +686,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
                  dependencies: [
                    Bibliothecary::Dependency.new(
                      platform: "maven",
-                     name: ":client",
+                     name: "subproject:client",
                      requirement: "0.0.0",
                      original_name: "my-group:common-job-update-gateway-compress",
                      original_requirement: "5.0.2",
@@ -734,7 +734,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
       GRADLE
 
       expect(described_class.parse_gradle_resolved(gradle_dependencies_out)).to eq Bibliothecary::ParserResult.new(
-        project_name: ":submodules:test",
+        project_name: "subproject:submodules:test",
         dependencies: []
       )
     end
@@ -859,13 +859,13 @@ RSpec.describe Bibliothecary::Parsers::Maven do
       expect(results).to eq({
                               parser: "maven",
                               path: "gradle-dependencies-q.txt",
-                              project_name: ":utilities",
+                              project_name: "subproject:utilities",
                               kind: "lockfile",
                               success: true,
                               dependencies: [
-          Bibliothecary::Dependency.new(name: ":list", requirement: "0.0.0", type: "compileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
+          Bibliothecary::Dependency.new(name: "subproject:list", requirement: "0.0.0", type: "compileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "org.fusesource.jansi:jansi", requirement: "2.4.1", type: "compileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
-          Bibliothecary::Dependency.new(name: ":list", requirement: "0.0.0", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
+          Bibliothecary::Dependency.new(name: "subproject:list", requirement: "0.0.0", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "com.google.guava:guava", requirement: "33.0.0-jre", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "com.google.guava:failureaccess", requirement: "1.0.2", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "com.google.guava:listenablefuture", requirement: "9999.0-empty-to-avoid-conflict-with-guava", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
@@ -873,7 +873,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
           Bibliothecary::Dependency.new(name: "org.checkerframework:checker-qual", requirement: "3.41.0", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "com.google.errorprone:error_prone_annotations", requirement: "2.23.0", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "org.fusesource.jansi:jansi", requirement: "2.4.1", type: "runtimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
-          Bibliothecary::Dependency.new(name: ":list", requirement: "0.0.0", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
+          Bibliothecary::Dependency.new(name: "subproject:list", requirement: "0.0.0", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "org.fusesource.jansi:jansi", requirement: "2.4.1", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "org.junit.jupiter:junit-jupiter", requirement: "5.12.1", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "org.junit:junit-bom", requirement: "5.12.1", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
@@ -882,7 +882,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
           Bibliothecary::Dependency.new(name: "org.junit.platform:junit-platform-commons", requirement: "1.12.1", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "org.opentest4j:opentest4j", requirement: "1.3.0", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "org.apiguardian:apiguardian-api", requirement: "1.1.2", type: "testCompileClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
-          Bibliothecary::Dependency.new(name: ":list", requirement: "0.0.0", type: "testRuntimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
+          Bibliothecary::Dependency.new(name: "subproject:list", requirement: "0.0.0", type: "testRuntimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "com.google.guava:guava", requirement: "33.0.0-jre", type: "testRuntimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "com.google.guava:failureaccess", requirement: "1.0.2", type: "testRuntimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
           Bibliothecary::Dependency.new(name: "com.google.guava:listenablefuture", requirement: "9999.0-empty-to-avoid-conflict-with-guava", type: "testRuntimeClasspath", platform: "maven", source: "gradle-dependencies-q.txt"),
@@ -913,7 +913,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
       results = described_class.analyse_contents("gradle-dependencies-q.txt", lockfile)
       puts results
       expect(results[:success]).to be true
-      expect(results[:project_name]).to eq("build-logic")
+      expect(results[:project_name]).to eq("subproject:build-logic")
     end
   end
 


### PR DESCRIPTION
e.g. for project names, `subproject:app` will be the name that we return for this sample line:

`Project ':app'`

e.g. for dependencies, `subproject:utilities` will be the name that we return for this sample line:

`+--- project :utilities`

This makes the names for these dependencies more Maven-friendly without having to manipulate them.
