### PR TITLE
15.5.0: move gradle-dependencies-q.txt line parsing into a single regexp.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [15.5.0]
+
+### Changed
+
+- Massive improvement in Bibliothecary::Parsers::Maven.parse_resolved_gradle_dep_line() by moving all the GAV parsing to a regular expression.
+
 ## [15.4.0]
 
 ### Added

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -18,22 +18,64 @@ module Bibliothecary
       # e.g. "annotationProcessor - Annotation processors and their dependencies for source set 'main'."
       GRADLE_TYPE_REGEXP = /^(\w+)/
 
-      # e.g. "|    \\--- com.google.guava:guava:23.5-jre (*)"
-      GRADLE_DEP_REGEXP = /(\+---|\\---){1}/
-
-      GRADLE_ARROW_REGEXP = / -> /
-
       # The name of the project containing the given dependencies
       GRADLE_PROJECT_REGEXP = /\s*(Root p|P)roject '?(:?[^\s']+)'?/
 
-      # Dependencies that are on-disk projects, eg:
-      # e.g. "\--- project :api:my-internal-project"
-      # e.g. "+--- my-group:my-alias:1.2.3 -> project :client (*)"
-      GRADLE_DEPENDENCY_PROJECT_REGEXP = /project (:?\S+)?/
+      # Matches a single dependency line from `gradle dependencies -q` output and extracts
+      # named captures for all relevant fields. Handles these line shapes:
+      #   +--- group:artifact:version                          (simple dep)
+      #   +--- group:artifact:version (*)                      (already resolved elsewhere)
+      #   +--- group:artifact:version (c)                      (dependency constraint)
+      #   +--- group:artifact:v1 -> v2                         (version override)
+      #   +--- group:artifact:[1.0, 2.0) -> 1.5               (version range override)
+      #   +--- group:artifact -> v2                            (version resolved via BOM/constraint)
+      #   +--- g1:a1:v1 -> g2:a2:v2                           (coordinate alias)
+      #   +--- g1:a1 -> g2:a2:v2                              (alias, no original version)
+      #   +--- group:artifact:version FAILED                   (resolution failed, version present)
+      #   +--- project :path                                   (project dependency)
+      #   +--- project :path -> project :other                 (project-to-project redirect)
+      #   +--- g:a:v -> project :name                          (alias to project)
+      #
+      # Lines ending with (n) are excluded by omitting "n" from the suffix pattern,
+      # so they naturally fail to match. Lines like "group:artifact FAILED" (no version)
+      # also fail because the simple-dep branch requires 3+ colon-separated parts.
+      #
+      # Named captures: orig_name, orig_ver, res_name, res_ver, project
+      #
+      # Version part: either a simple token ([^\s:]+) or a bracket-delimited range like [1.0, 2.0)
+      # Maven ranges can use [ or ( for open and ] or ) for close, e.g. [3.0.4, 3.5.0)
+      GRADLE_VERSION_PART = /[^\s:]+|[\[(][^\])]*[\])]/
+      GRADLE_DEP_LINE_REGEXP = /
+        (?:\+---|\\---)                                                   # tree connector
+        \s+                                                               # whitespace after connector
+        (?:
+          # Project -> project redirect
+          project\s+\S+                                                   # left-side project (not captured)
+          \s+->\s+                                                        # arrow
+          project\s+(?<project>:?\S+)                                     # right-side project
 
-      # line ending legend: (c) means a dependency constraint, (n) means not resolved, or (*) means resolved previously, e.g. org.springframework.boot:spring-boot-starter-web:2.1.0.M3 (*)
-      # e.g. the "(n)" in "+--- my-group:my-name:1.2.3 (n)"
-      GRADLE_LINE_ENDING_REGEXP = /(\((c|n|\*)\))$/
+        |
+          # Arrow: original -> resolved
+          (?<orig_name>[^\s:]+:[^\s:]+)(?::(?<orig_ver>#{GRADLE_VERSION_PART}))?  # original dep (group:artifact[:version])
+          \s+->\s+                                                         # arrow
+          (?:
+            project\s+(?<project>:?\S+)                                    # -> project
+            |
+            (?<res_name>[^\s:]+:[^\s:]+(?::[^\s:]+)*):(?<res_ver>[^\s:]+)  # -> full coordinate (g:a:v)
+            |
+            (?<res_ver>[^\s:]+)                                            # -> version only
+          )
+        |
+          # Standalone project dependency
+          project\s+(?<project>:?\S+)
+        |
+          # Simple dependency (requires 3+ colon parts: group:artifact:version)
+          (?<res_name>[^\s:]+:[^\s:]+(?::[^\s:]+)*):(?<res_ver>[^\s:]+)
+        )
+        (?:\s+FAILED)?                                                     # optional FAILED suffix
+        (?:\s*\([c*]\))?                                                   # optional (c) or (*) suffix; (n) excluded
+        \s*$                                                               # end of line
+      /x
 
       # Builtin methods: https://docs.gradle.org/current/userguide/java_plugin.html#tab:configurations
       # Deprecated methods: https://docs.gradle.org/current/userguide/upgrading_version_6.html#sec:configuration_removal
@@ -224,60 +266,32 @@ module Bibliothecary
       end
 
       def self.parse_resolved_gradle_dep_line(line, current_type: nil, keep_subprojects: false, source: nil)
-        return if line.end_with?("(n)") # skip unresolved or already-resolved dependencies
+        m = GRADLE_DEP_LINE_REGEXP.match(line)
+        return unless m
 
-        gradle_dep_match = GRADLE_DEP_REGEXP.match(line)
-        return unless gradle_dep_match
-
-        # omit Gradle project dependencies
-        if (project_match = line.match(GRADLE_DEPENDENCY_PROJECT_REGEXP))
+        if m[:project]
           return unless keep_subprojects
 
           # an empty project name is self-referential (i.e. a cycle), and we don't need to track the manifest's
           # project itself, e.g. "+--- project :"
-          return if project_match[1].nil?
+          return if m[:project].nil?
 
-          sub_project_name = project_match[1]
-          # gradle sub-project versions cannot be specified when including them (gradle just uses whichever version is in the
-          # codebase), and their versions are 'unspecified' if not set, so just use a placeholder version since it doesn't matter.
-          # the name also doesn't include a project, so we use "subproject:" prefix to denote that these are subproject deps.
-          line = line.sub(project_match[0], "subproject#{sub_project_name}:0.0.0")
-        end
-
-        cleaned_line = line
-          .split(gradle_dep_match.captures[0])[1]
-          .sub(GRADLE_LINE_ENDING_REGEXP, "")
-          .sub(/ FAILED$/, "") # dependency could not be resolved (but still may have a version)
-          .strip
-
-        # " -> " is either for an aliased dependency, or a version that was resolved from a different requirement or no requirement.
-        if cleaned_line.include?(" -> ")
-          original_depstring, resolved_depstring = cleaned_line.split(" -> ", 2)
-
-          parts = original_depstring.split(":")
-          original_name = parts[0..1].join(":") # original at minimum will have a 2-part name
-          original_requirement = parts[2] || "*"
-
-          parts = resolved_depstring.split(":")
-          resolved_requirement = parts.pop # resolved at minimum will have a 1-part version
-          resolved_name = parts.join(":")
-
-          # this case is not an actual alias, just a different version was resolved, so won't keep track of original
-          if resolved_name.empty? && !original_name.empty?
-            resolved_name = original_name
-            original_name = nil
-            original_requirement = nil
-          end
+          resolved_name = "subproject#{m[:project]}"
+          resolved_requirement = "0.0.0"
+          original_name = m[:orig_name]
+          original_requirement = m[:orig_ver] || "*" if original_name
+        elsif m[:res_name]
+          # full coordinate on resolved side — true alias if orig_name is present
+          resolved_name = m[:res_name]
+          resolved_requirement = m[:res_ver]
+          original_name = m[:orig_name]
+          original_requirement = m[:orig_ver] || "*" if original_name
         else
+          # version-only resolve (g:a:v1 -> v2) or simple dep (g:a:v) — not a true alias
+          resolved_name = m[:orig_name] || m[:res_name]
+          resolved_requirement = m[:res_ver]
           original_name = nil
           original_requirement = nil
-
-          # handle simple resolved dep
-          parts = cleaned_line.split(":")
-          return if parts.size < 3 # we didn't get a full name and version, so skip it
-
-          resolved_requirement = parts.pop
-          resolved_name = parts.join(":")
         end
 
         Dependency.new(

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -267,7 +267,7 @@ module Bibliothecary
       end
 
       def self.parse_resolved_gradle_dep_line(line, current_type: nil, keep_subprojects: false, source: nil)
-        return if line.end_with?("(n)")
+        return if line.end_with?("(n)") # skip unresolved or already-resolved dependencies
 
         m = GRADLE_DEP_LINE_REGEXP.match(line)
         return unless m

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -21,16 +21,42 @@ module Bibliothecary
       # The name of the project containing the given dependencies
       GRADLE_PROJECT_REGEXP = /\s*(Root p|P)roject '?(:?[^\s']+)'?/
 
+      # Version: simple token or bracket-delimited range like [1.0, 2.0)
+      GRADLE_VERSION_PART = /[^\s:]+|[\[(][^\])]*[\])]/
+
+      # --- Individual branch patterns (each handles one line shape) ---
+
+      # project :foo -> project :bar
+      GRADLE_PROJECT_REDIRECT = /project\s+\S+\s+->\s+project\s+(?<project>:?\S+)/
+
+      # group:artifact[:version] -> (project | g:a:v | version)
+      GRADLE_ARROW_DEP = /
+        (?<orig_name>[^\s:]+:[^\s:]+)(?::(?<orig_ver>#{GRADLE_VERSION_PART}))?
+        \s+->\s+
+        (?:
+          project\s+(?<project>:?\S+)
+        | (?<res_name>[^\s:]+:[^\s:]+(?::[^\s:]+)*):(?<res_ver>[^\s:]+)
+        | (?<res_ver>[^\s:]+)
+        )
+      /x
+
+      # project :foo (standalone)
+      GRADLE_STANDALONE_PROJECT = /project\s+(?<project>:?\S+)/
+
+      # group:artifact:version (simple dependency, 3+ colon-separated parts)
+      GRADLE_SIMPLE_DEP = /(?<res_name>[^\s:]+:[^\s:]+(?::[^\s:]+)*):(?<res_ver>[^\s:]+)/
+
+      # --- Composed full-line pattern ---
       # Matches a single dependency line from `gradle dependencies -q` output and extracts
       # named captures for all relevant fields. Handles these line shapes:
       #   +--- group:artifact:version                          (simple dep)
       #   +--- group:artifact:version (*)                      (already resolved elsewhere)
       #   +--- group:artifact:version (c)                      (dependency constraint)
       #   +--- group:artifact:v1 -> v2                         (version override)
-      #   +--- group:artifact:[1.0, 2.0) -> 1.5               (version range override)
+      #   +--- group:artifact:[1.0, 2.0) -> 1.5                (version range override)
       #   +--- group:artifact -> v2                            (version resolved via BOM/constraint)
-      #   +--- g1:a1:v1 -> g2:a2:v2                           (coordinate alias)
-      #   +--- g1:a1 -> g2:a2:v2                              (alias, no original version)
+      #   +--- g1:a1:v1 -> g2:a2:v2                            (coordinate alias)
+      #   +--- g1:a1 -> g2:a2:v2                               (alias, no original version)
       #   +--- group:artifact:version FAILED                   (resolution failed, version present)
       #   +--- project :path                                   (project dependency)
       #   +--- project :path -> project :other                 (project-to-project redirect)
@@ -44,37 +70,12 @@ module Bibliothecary
       #
       # Version part: either a simple token ([^\s:]+) or a bracket-delimited range like [1.0, 2.0)
       # Maven ranges can use [ or ( for open and ] or ) for close, e.g. [3.0.4, 3.5.0)
-      GRADLE_VERSION_PART = /[^\s:]+|[\[(][^\])]*[\])]/
       GRADLE_DEP_LINE_REGEXP = /
-        (?:\+---|\\---)                                                   # tree connector
-        \s+                                                               # whitespace after connector
-        (?:
-          # Project -> project redirect
-          project\s+\S+                                                   # left-side project (not captured)
-          \s+->\s+                                                        # arrow
-          project\s+(?<project>:?\S+)                                     # right-side project
-
-        |
-          # Arrow: original -> resolved
-          (?<orig_name>[^\s:]+:[^\s:]+)(?::(?<orig_ver>#{GRADLE_VERSION_PART}))?  # original dep (group:artifact[:version])
-          \s+->\s+                                                         # arrow
-          (?:
-            project\s+(?<project>:?\S+)                                    # -> project
-            |
-            (?<res_name>[^\s:]+:[^\s:]+(?::[^\s:]+)*):(?<res_ver>[^\s:]+)  # -> full coordinate (g:a:v)
-            |
-            (?<res_ver>[^\s:]+)                                            # -> version only
-          )
-        |
-          # Standalone project dependency
-          project\s+(?<project>:?\S+)
-        |
-          # Simple dependency (requires 3+ colon parts: group:artifact:version)
-          (?<res_name>[^\s:]+:[^\s:]+(?::[^\s:]+)*):(?<res_ver>[^\s:]+)
-        )
-        (?:\s+FAILED)?                                                     # optional FAILED suffix
-        (?:\s*\([c*]\))?                                                   # optional (c) or (*) suffix; (n) excluded
-        \s*$                                                               # end of line
+        (?:\+---|\\---)\s+
+        (?:#{GRADLE_PROJECT_REDIRECT}|#{GRADLE_ARROW_DEP}|#{GRADLE_STANDALONE_PROJECT}|#{GRADLE_SIMPLE_DEP})
+        (?:\s+FAILED)?
+        (?:\s*\([c*]\))?
+        \s*$
       /x
 
       # Builtin methods: https://docs.gradle.org/current/userguide/java_plugin.html#tab:configurations
@@ -266,6 +267,8 @@ module Bibliothecary
       end
 
       def self.parse_resolved_gradle_dep_line(line, current_type: nil, keep_subprojects: false, source: nil)
+        return if line.end_with?("(n)")
+
         m = GRADLE_DEP_LINE_REGEXP.match(line)
         return unless m
 

--- a/lib/bibliothecary/parsers/npm.rb
+++ b/lib/bibliothecary/parsers/npm.rb
@@ -439,8 +439,8 @@ module Bibliothecary
       end
 
       def self.lockfile_preference_order(file_infos)
-        files = file_infos.each_with_object({}) do |file_info, obj|
-          obj[File.basename(file_info.full_path)] = file_info
+        files = file_infos.to_h do |file_info|
+          [File.basename(file_info.full_path), file_info]
         end
 
         if files["npm-shrinkwrap.json"]

--- a/lib/bibliothecary/parsers/pypi.rb
+++ b/lib/bibliothecary/parsers/pypi.rb
@@ -175,7 +175,7 @@ module Bibliothecary
         file_contents
           .fetch("dependency-groups", {})
           .each_pair do |group_name, group_deps|
-            parsed_deps = group_deps.select { |d| d.is_a?(String) }.map { |d| parse_pep_508_dep_spec(d) }
+            parsed_deps = group_deps.grep(String).map { |d| parse_pep_508_dep_spec(d) }
             deps += map_dependencies(parsed_deps, group_name, options.fetch(:filename, nil))
           end
 

--- a/spec/fixtures/gradle-dependencies-q.txt
+++ b/spec/fixtures/gradle-dependencies-q.txt
@@ -1012,6 +1012,8 @@ runtimeClasspath - Runtime classpath of source set 'main'.
 +--- org.aspectj:aspectjrt:1.9.1
 +--- org.aspectj:aspectjweaver:1.9.1
 \--- javax.validation:validation-api:2.0.1.Final
++--- org.codehaus.woodstox:stax2-api:[3.0.4, 3.5.0) -> 3.1.4
++--- project :private:old-it-utils:it-plugins -> project :private:it-utils:it-plugins
 
 runtimeElements - Elements of runtime for main. (n)
 No dependencies

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -616,7 +616,7 @@ RSpec.describe Bibliothecary::Parsers::Maven do
 
       runtime_classpath = deps[:dependencies].select { |item| item.type == "runtimeClasspath" }
 
-      expect(runtime_classpath.length).to eq 159
+      expect(runtime_classpath.length).to eq 161
       expect(runtime_classpath.select { |item| item.name == "com.google.guava:guava" }.length).to eq 1
 
       # test rename resolutions
@@ -750,6 +750,38 @@ RSpec.describe Bibliothecary::Parsers::Maven do
                    type: nil
                  )]
                ))
+    end
+
+    it "parses version range to resolved version syntax" do
+      version_range = "+--- org.codehaus.woodstox:stax2-api:[3.0.4, 3.5.0) -> 3.1.4"
+      expect(described_class.parse_gradle_resolved(version_range))
+        .to eq(Bibliothecary::ParserResult.new(
+                 dependencies: [Bibliothecary::Dependency.new(
+                   platform: "maven",
+                   name: "org.codehaus.woodstox:stax2-api",
+                   requirement: "3.1.4",
+                   type: nil
+                 )]
+               ))
+    end
+
+    it "parses project-to-project redirects" do
+      project_redirect = "+--- project :private:old-it-utils:it-plugins -> project :private:it-utils:it-plugins"
+      expect(described_class.parse_gradle_resolved(project_redirect, options: { keep_subprojects_in_maven_tree: true }))
+        .to eq(Bibliothecary::ParserResult.new(
+                 dependencies: [Bibliothecary::Dependency.new(
+                   platform: "maven",
+                   name: "subproject:private:it-utils:it-plugins",
+                   requirement: "0.0.0",
+                   type: nil
+                 )]
+               ))
+    end
+
+    it "excludes project-to-project redirects when keep_subprojects is false" do
+      project_redirect = "+--- project :private:it-branch:it-plugins -> project :private:it-alm:it-plugins"
+      expect(described_class.parse_gradle_resolved(project_redirect))
+        .to eq(Bibliothecary::ParserResult.new(dependencies: []))
     end
 
     def is_self_dep?(dep)


### PR DESCRIPTION
The goal here was to reduce String allocations as much as possible, and it worked. The code is simpler too.