### PR TITLE
[15.5.0] Nuget: return all dependencies from project.assets.json, instead of one target frameworks' dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [15.5.0]
+
+### Changed
+
+- Fix Nuget parser so it returns all target frameworks' dependencies from project.assets.json instead of an arbitrary target framework's dependencies.
+
 ## [15.4.0]
 
 ### Added

--- a/lib/bibliothecary/parsers/npm.rb
+++ b/lib/bibliothecary/parsers/npm.rb
@@ -439,8 +439,8 @@ module Bibliothecary
       end
 
       def self.lockfile_preference_order(file_infos)
-        files = file_infos.each_with_object({}) do |file_info, obj|
-          obj[File.basename(file_info.full_path)] = file_info
+        files = file_infos.to_h do |file_info|
+          [File.basename(file_info.full_path), file_info]
         end
 
         if files["npm-shrinkwrap.json"]

--- a/lib/bibliothecary/parsers/nuget.rb
+++ b/lib/bibliothecary/parsers/nuget.rb
@@ -215,31 +215,31 @@ module Bibliothecary
       def self.parse_project_assets_json(file_contents, options: {})
         manifest = JSON.parse file_contents
 
-        frameworks = {}
-        manifest.fetch("targets", []).each do |framework, deps|
-          frameworks[framework] = deps
-            .select { |_name, details| details["type"] == "package" }
-            .map do |name, _details|
-              name_split = name.split("/")
-              Dependency.new(
-                name: name_split[0],
-                requirement: name_split[1],
-                type: "runtime",
-                source: options.fetch(:filename, nil),
-                platform: platform_name
-              )
-            end
-        end
+        # NOTE: here we are merging dependencies from potentially >1 target framework. The versions
+        # across target frameworks in project.assets.json are not guaranteed to be the same, so e.g. a
+        # single project.assets.json may include both "Newtonsoft.Json@13.01" and "Newtonsoft.Json@12.0.3". This
+        # should be more comprehensive than just returning one arbitrary framework's deps, but we're losing the
+        # fidelity of which target framework a given dependency was used in. Someday, bibliothecary could
+        # include a new Dependency field like "architecture" or "framework" and add the metadata for each dep there.
+        dependencies = manifest
+          .fetch("targets", [])
+          .flat_map do |_framework, framework_dependencies|
+            framework_dependencies
+              .select { |_name, details| details["type"] == "package" }
+              .map do |name, _details|
+                name_split = name.split("/")
+                Dependency.new(
+                  name: name_split[0],
+                  requirement: name_split[1],
+                  type: "runtime",
+                  source: options.fetch(:filename, nil),
+                  platform: platform_name
+                )
+              end
+          end
+          .uniq
 
-        unless frameworks.empty?
-          # we should really return multiple manifests, but bibliothecary doesn't
-          # do that yet so at least pick deterministically.
-
-          # Note, frameworks can be empty, so remove empty ones and then return the last sorted item if any
-          frameworks.delete_if { |_k, v| v.empty? }
-          return ParserResult.new(dependencies: frameworks[frameworks.keys.max]) unless frameworks.empty?
-        end
-        ParserResult.new(dependencies: [])
+        ParserResult.new(dependencies: dependencies)
       end
     end
   end

--- a/lib/bibliothecary/parsers/pypi.rb
+++ b/lib/bibliothecary/parsers/pypi.rb
@@ -175,7 +175,7 @@ module Bibliothecary
         file_contents
           .fetch("dependency-groups", {})
           .each_pair do |group_name, group_deps|
-            parsed_deps = group_deps.select { |d| d.is_a?(String) }.map { |d| parse_pep_508_dep_spec(d) }
+            parsed_deps = group_deps.grep(String).map { |d| parse_pep_508_dep_spec(d) }
             deps += map_dependencies(parsed_deps, group_name, options.fetch(:filename, nil))
           end
 

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bibliothecary
-  VERSION = "15.4.0"
+  VERSION = "15.5.0"
 end

--- a/spec/parsers/nuget_spec.rb
+++ b/spec/parsers/nuget_spec.rb
@@ -652,6 +652,7 @@ describe Bibliothecary::Parsers::Nuget do
       parser: "nuget",
       path: "project.assets.json",
       dependencies: [
+        Bibliothecary::Dependency.new(platform: "nuget", name: "c", requirement: "1.0.0", type: "runtime", source: "project.assets.json"),
         Bibliothecary::Dependency.new(platform: "nuget", name: "a", requirement: "1.0.0", type: "runtime", source: "project.assets.json"),
         Bibliothecary::Dependency.new(platform: "nuget", name: "b", requirement: "1.0.0", type: "runtime", source: "project.assets.json"),
       ],


### PR DESCRIPTION
This is the same as https://github.com/librariesio/bibliothecary/pull/653, but for `project.assets.json` lock files